### PR TITLE
add Zenodo integration file

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,14 @@
+{
+    "description": "Structure-Preserving Numerical Methods for Dispersive Shallow Water Models",
+    "license": "MIT",
+    "title": "DispersiveShallowWater.jl",
+    "upload_type": "software",
+    "creators": [
+        {
+            "affiliation": "Applied Mathematics, University of Hamburg, Germany",
+            "name": "Lampert, Joshua",
+            "orcid": "0009-0007-0971-6709"
+        }
+    ],
+    "access_right": "open"
+}


### PR DESCRIPTION
You can log in to http://zenodo.org using your GitHub account. Then, you can enable tracking of this repo by Zenodo. If you create a new tag, Zenodo will grab it and create a DOI for this repo (that can be used to cite this software).

The file I added here will be read by Zenodo to generate appropriate citation information.