### PR TITLE
Add `SummaryCallback`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -17,6 +17,7 @@ SimpleUnPack = "ce78b400-467f-4804-87d8-8f486da07d0a"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 SummationByPartsOperators = "9f78cca6-572e-554e-b819-917d2f1cf240"
+TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 
 [compat]
 DiffEqBase = "6.121"
@@ -32,4 +33,5 @@ SimpleUnPack = "1.1"
 SparseArrays = "1"
 StaticArrays = "1"
 SummationByPartsOperators = "0.5.41"
+TimerOutputs = "0.5"
 julia = "1.8"

--- a/examples/bbm_bbm_1d/bbm_bbm_1d_basic.jl
+++ b/examples/bbm_bbm_1d/bbm_bbm_1d_basic.jl
@@ -28,11 +28,12 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_1d/bbm_bbm_1d_dg.jl
+++ b/examples/bbm_bbm_1d/bbm_bbm_1d_dg.jl
@@ -39,11 +39,12 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_1d/bbm_bbm_1d_manufactured.jl
+++ b/examples/bbm_bbm_1d/bbm_bbm_1d_manufactured.jl
@@ -29,11 +29,12 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 1.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_1d/bbm_bbm_1d_relaxation.jl
+++ b/examples/bbm_bbm_1d/bbm_bbm_1d_relaxation.jl
@@ -28,13 +28,14 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
 relaxation_callback = RelaxationCallback(invariant = entropy)
 # Always put relaxation_callback before analysis_callback to guarantee conservation of the invariant
-callbacks = CallbackSet(relaxation_callback, analysis_callback)
+callbacks = CallbackSet(relaxation_callback, analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_basic.jl
+++ b/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_basic.jl
@@ -28,11 +28,12 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_dg_upwind_relaxation.jl
+++ b/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_dg_upwind_relaxation.jl
@@ -38,13 +38,14 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
 relaxation_callback = RelaxationCallback(invariant = entropy)
 # Always put relaxation_callback before analysis_callback to guarantee conservation of the invariant
-callbacks = CallbackSet(relaxation_callback, analysis_callback)
+callbacks = CallbackSet(relaxation_callback, analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_dingemans.jl
+++ b/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_dingemans.jl
@@ -27,11 +27,12 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 70.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 500)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_manufactured.jl
+++ b/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_manufactured.jl
@@ -29,11 +29,12 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 1.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_relaxation.jl
+++ b/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_relaxation.jl
@@ -32,13 +32,14 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
 relaxation_callback = RelaxationCallback(invariant = entropy)
 # Always put relaxation_callback before analysis_callback to guarantee conservation of the invariant
-callbacks = CallbackSet(relaxation_callback, analysis_callback)
+callbacks = CallbackSet(relaxation_callback, analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_upwind_relaxation.jl
+++ b/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_upwind_relaxation.jl
@@ -34,13 +34,14 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
 relaxation_callback = RelaxationCallback(invariant = entropy)
 # Always put relaxation_callback before analysis_callback to guarantee conservation of the invariant
-callbacks = CallbackSet(relaxation_callback, analysis_callback)
+callbacks = CallbackSet(relaxation_callback, analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_well_balanced.jl
+++ b/examples/bbm_bbm_variable_bathymetry_1d/bbm_bbm_variable_bathymetry_1d_well_balanced.jl
@@ -51,13 +51,14 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 30.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy,
                                                                  lake_at_rest_error))
 # Always put relaxation_callback before analysis_callback to guarantee conservation of the invariant
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 dt = 0.5
 saveat = range(tspan..., length = 100)

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans.jl
@@ -28,12 +28,13 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 70.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  entropy,
                                                                  entropy_modified))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 500)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans_cg.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans_cg.jl
@@ -35,12 +35,13 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 70.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  entropy,
                                                                  entropy_modified))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 500)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans_relaxation.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans_relaxation.jl
@@ -28,6 +28,7 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 70.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
@@ -35,7 +36,7 @@ analysis_callback = AnalysisCallback(semi; interval = 10,
                                                                  entropy_modified))
 relaxation_callback = RelaxationCallback(invariant = entropy_modified)
 # Always put relaxation_callback before analysis_callback to guarantee conservation of the invariant
-callbacks = CallbackSet(relaxation_callback, analysis_callback)
+callbacks = CallbackSet(relaxation_callback, analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 500)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans_upwind.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans_upwind.jl
@@ -33,13 +33,14 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 70.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  entropy,
                                                                  entropy_modified))
 
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 500)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_manufactured.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_manufactured.jl
@@ -32,11 +32,12 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 1.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  velocity, entropy))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
 sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_well_balanced.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_well_balanced.jl
@@ -50,12 +50,13 @@ semi = Semidiscretization(mesh, equations, initial_condition, solver,
 # Create `ODEProblem` and run the simulation
 tspan = (0.0, 10.0)
 ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 10,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
                                                                  momentum, entropy,
                                                                  lake_at_rest_error))
-callbacks = CallbackSet(analysis_callback)
+callbacks = CallbackSet(analysis_callback, summary_callback)
 
 # Need a very small time step for stability
 dt = 0.0002

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -21,6 +21,7 @@ using SummationByPartsOperators: AbstractDerivativeOperator,
                                  periodic_derivative_operator,
                                  derivative_order, integrate
 import SummationByPartsOperators: grid, xmin, xmax
+using TimerOutputs: TimerOutputs, TimerOutput, @timeit, print_timer, reset_timer!
 
 include("boundary_conditions.jl")
 include("mesh.jl")
@@ -52,7 +53,7 @@ export initial_condition_convergence_test,
        initial_condition_manufactured, source_terms_manufactured,
        initial_condition_dingemans
 
-export AnalysisCallback, RelaxationCallback
+export AnalysisCallback, RelaxationCallback, SummaryCallback
 export tstops, errors, integrals
 
 end

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -234,7 +234,8 @@ function (analysis_callback::AnalysisCallback)(io, u_ode, integrator, semi)
                 "               " *
                 " └── GC time:    " *
                 @sprintf("%10.8e s (%5.3f%%)", gc_time_absolute, gc_time_percentage))
-        println(io, " sim. time:      " * @sprintf("%10.8e (%5.3f%%)", t, sim_time_percentage))
+        println(io,
+                " sim. time:      " * @sprintf("%10.8e (%5.3f%%)", t, sim_time_percentage))
         println(io,
                 " #DOF:           " * @sprintf("% 14d", nnodes(semi)) *
                 "               " *

--- a/src/callbacks_step/callbacks_step.jl
+++ b/src/callbacks_step/callbacks_step.jl
@@ -8,3 +8,4 @@ end
 
 include("relaxation.jl")
 include("analysis.jl")
+include("summary.jl")

--- a/src/callbacks_step/relaxation.jl
+++ b/src/callbacks_step/relaxation.jl
@@ -91,14 +91,15 @@ end
     energy_old = relaxation_functional(uold, semi)
 
     @timeit timer() "relaxation" begin
-        if (relaxation_functional(convex_combination(gamma_lo, uold, unew), semi) - energy_old) *
-        (relaxation_functional(convex_combination(gamma_hi, uold, unew), semi) - energy_old) >
-        0
+        if (relaxation_functional(convex_combination(gamma_lo, uold, unew), semi) -
+            energy_old) *
+           (relaxation_functional(convex_combination(gamma_hi, uold, unew), semi) -
+            energy_old) > 0
             terminate_integration = true
         else
             gamma = find_zero(g -> relaxation_functional(convex_combination(g, uold, unew),
-                                                        semi) -
-                                energy_old, (gamma_lo, gamma_hi), AlefeldPotraShi())
+                                                         semi) -
+                                   energy_old, (gamma_lo, gamma_hi), AlefeldPotraShi())
         end
 
         if gamma < eps(typeof(gamma))
@@ -116,7 +117,6 @@ end
         if terminate_integration
             terminate!(integrator)
         end
-
     end
     return nothing
 end

--- a/src/callbacks_step/relaxation.jl
+++ b/src/callbacks_step/relaxation.jl
@@ -90,31 +90,33 @@ end
     end
     energy_old = relaxation_functional(uold, semi)
 
-    if (relaxation_functional(convex_combination(gamma_lo, uold, unew), semi) - energy_old) *
-       (relaxation_functional(convex_combination(gamma_hi, uold, unew), semi) - energy_old) >
-       0
-        terminate_integration = true
-    else
-        gamma = find_zero(g -> relaxation_functional(convex_combination(g, uold, unew),
-                                                     semi) -
-                               energy_old, (gamma_lo, gamma_hi), AlefeldPotraShi())
-    end
+    @timeit timer() "relaxation" begin
+        if (relaxation_functional(convex_combination(gamma_lo, uold, unew), semi) - energy_old) *
+        (relaxation_functional(convex_combination(gamma_hi, uold, unew), semi) - energy_old) >
+        0
+            terminate_integration = true
+        else
+            gamma = find_zero(g -> relaxation_functional(convex_combination(g, uold, unew),
+                                                        semi) -
+                                energy_old, (gamma_lo, gamma_hi), AlefeldPotraShi())
+        end
 
-    if gamma < eps(typeof(gamma))
-        terminate_integration = true
-    end
+        if gamma < eps(typeof(gamma))
+            terminate_integration = true
+        end
 
-    unew .= convex_combination(gamma, uold, unew)
-    unew_ode = reshape(unew, prod(size(unew)))
-    DiffEqBase.set_u!(integrator, unew_ode)
-    if !isapprox(tnew, first(integrator.opts.tstops))
-        tgamma = convex_combination(gamma, told, tnew)
-        DiffEqBase.set_t!(integrator, tgamma)
-    end
+        unew .= convex_combination(gamma, uold, unew)
+        unew_ode = reshape(unew, prod(size(unew)))
+        DiffEqBase.set_u!(integrator, unew_ode)
+        if !isapprox(tnew, first(integrator.opts.tstops))
+            tgamma = convex_combination(gamma, told, tnew)
+            DiffEqBase.set_t!(integrator, tgamma)
+        end
 
-    if terminate_integration
-        terminate!(integrator)
-    end
+        if terminate_integration
+            terminate!(integrator)
+        end
 
+    end
     return nothing
 end

--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -1,0 +1,52 @@
+"""
+    SummaryCallback(io::IO = stdout)
+
+Create and return a callback that prints a human-readable summary of the simulation setup at the
+beginning of a simulation and then resets the timer. When the returned callback is executed
+directly, the current timer values are shown.
+"""
+struct SummaryCallback
+    io::IO
+
+    function SummaryCallback(io::IO = stdout)
+        function initialize(cb, u, t, integrator)
+            initialize_summary_callback(cb, u, t, integrator)
+        end
+        summary_callback = new(io)
+        # SummaryCallback is called at end of simulation
+        condition = (u, t, integrator) -> isfinished(integrator)
+        DiscreteCallback(condition, summary_callback,
+                         save_positions = (false, false),
+                         initialize = initialize)
+    end
+end
+
+function Base.show(io::IO, cb::DiscreteCallback{<:Any, <: SummaryCallback})
+    @nospecialize cb # reduce precompilation time
+
+    print(io, "SummaryCallback")
+end
+
+function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator)
+    reset_timer!(timer())
+    return nothing
+end
+
+
+function (cb::SummaryCallback)(integrator)
+    u_modified!(integrator, false)
+    cb()
+end
+
+function (summary_callback::SummaryCallback)()
+
+    io = summary_callback.io
+    TimerOutputs.complement!(timer())
+    print_timer(io, timer(), title = "DispersiveSWE",
+                allocations = true, linechars = :unicode, compact = false)
+    println(io)
+    return nothing
+end
+
+# Allow calling the callback explicitly
+(cb::DiscreteCallback{Condition, Affect!})() where {Condition, Affect! <: SummaryCallback} = cb.affect!()

--- a/src/callbacks_step/summary.jl
+++ b/src/callbacks_step/summary.jl
@@ -21,7 +21,7 @@ struct SummaryCallback
     end
 end
 
-function Base.show(io::IO, cb::DiscreteCallback{<:Any, <: SummaryCallback})
+function Base.show(io::IO, cb::DiscreteCallback{<:Any, <:SummaryCallback})
     @nospecialize cb # reduce precompilation time
 
     print(io, "SummaryCallback")
@@ -32,14 +32,12 @@ function initialize_summary_callback(cb::DiscreteCallback, u, t, integrator)
     return nothing
 end
 
-
 function (cb::SummaryCallback)(integrator)
     u_modified!(integrator, false)
     cb()
 end
 
 function (summary_callback::SummaryCallback)()
-
     io = summary_callback.io
     TimerOutputs.complement!(timer())
     print_timer(io, timer(), title = "DispersiveSWE",
@@ -49,4 +47,7 @@ function (summary_callback::SummaryCallback)()
 end
 
 # Allow calling the callback explicitly
-(cb::DiscreteCallback{Condition, Affect!})() where {Condition, Affect! <: SummaryCallback} = cb.affect!()
+function (cb::DiscreteCallback{Condition, Affect!})() where {Condition,
+                                                             Affect! <: SummaryCallback}
+    cb.affect!()
+end

--- a/src/equations/bbm_bbm_1d.jl
+++ b/src/equations/bbm_bbm_1d.jl
@@ -125,19 +125,22 @@ function rhs!(du_ode, u_ode, t, mesh, equations::BBMBBMEquations1D, initial_cond
     # energy and mass conservative semidiscretization
     if solver.D1 isa PeriodicDerivativeOperator ||
        solver.D1 isa UniformPeriodicCoupledOperator
-        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1 * (equations.D * v + eta .* v)
-        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1 * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:]=-solver.D1 * (equations.D * v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:]=-solver.D1 *
+                                              (equations.gravity * eta + 0.5 * v .^ 2)
     elseif solver.D1 isa PeriodicUpwindOperators
-        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1.central * (equations.D * v + eta .* v)
-        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1.central * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:]=-solver.D1.central *
+                                                  (equations.D * v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:]=-solver.D1.central *
+                                              (equations.gravity * eta + 0.5 * v .^ 2)
     else
         @error "unknown type of first-derivative operator"
     end
 
     @timeit timer() "source terms" calc_sources!(dq, q, t, source_terms, equations, solver)
 
-    @timeit timer() "deta elliptic" deta[:] = invImD2 * deta
-    @timeit timer() "dv elliptic" dv[:] = invImD2 * dv
+    @timeit timer() "deta elliptic" deta[:]=invImD2 * deta
+    @timeit timer() "dv elliptic" dv[:]=invImD2 * dv
 
     return nothing
 end

--- a/src/equations/bbm_bbm_1d.jl
+++ b/src/equations/bbm_bbm_1d.jl
@@ -125,19 +125,19 @@ function rhs!(du_ode, u_ode, t, mesh, equations::BBMBBMEquations1D, initial_cond
     # energy and mass conservative semidiscretization
     if solver.D1 isa PeriodicDerivativeOperator ||
        solver.D1 isa UniformPeriodicCoupledOperator
-        deta[:] = -solver.D1 * (equations.D * v + eta .* v)
-        dv[:] = -solver.D1 * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1 * (equations.D * v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1 * (equations.gravity * eta + 0.5 * v .^ 2)
     elseif solver.D1 isa PeriodicUpwindOperators
-        deta[:] = -solver.D1.central * (equations.D * v + eta .* v)
-        dv[:] = -solver.D1.central * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1.central * (equations.D * v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1.central * (equations.gravity * eta + 0.5 * v .^ 2)
     else
         @error "unknown type of first-derivative operator"
     end
 
-    calc_sources!(dq, q, t, source_terms, equations, solver)
+    @timeit timer() "source terms" calc_sources!(dq, q, t, source_terms, equations, solver)
 
-    deta[:] = invImD2 * deta
-    dv[:] = invImD2 * dv
+    @timeit timer() "deta elliptic" deta[:] = invImD2 * deta
+    @timeit timer() "dv elliptic" dv[:] = invImD2 * dv
 
     return nothing
 end

--- a/src/equations/bbm_bbm_variable_bathymetry_1d.jl
+++ b/src/equations/bbm_bbm_variable_bathymetry_1d.jl
@@ -190,19 +190,19 @@ function rhs!(du_ode, u_ode, t, mesh, equations::BBMBBMVariableEquations1D,
 
     if solver.D1 isa PeriodicDerivativeOperator ||
        solver.D1 isa UniformPeriodicCoupledOperator
-        deta[:] = -solver.D1 * (D .* v + eta .* v)
-        dv[:] = -solver.D1 * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1 * (D .* v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1 * (equations.gravity * eta + 0.5 * v .^ 2)
     elseif solver.D1 isa PeriodicUpwindOperators
-        deta[:] = -solver.D1.minus * (D .* v + eta .* v)
-        dv[:] = -solver.D1.plus * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1.minus * (D .* v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1.plus * (equations.gravity * eta + 0.5 * v .^ 2)
     else
         @error "unknown type of first-derivative operator"
     end
 
-    calc_sources!(dq, q, t, source_terms, equations, solver)
+    @timeit timer() "source terms" calc_sources!(dq, q, t, source_terms, equations, solver)
 
-    deta[:] = invImDKD * deta
-    dv[:] = invImD2K * dv
+    @timeit timer() "deta elliptic" deta[:] = invImDKD * deta
+    @timeit timer() "dv elliptic" dv[:] = invImD2K * dv
 
     return nothing
 end

--- a/src/equations/bbm_bbm_variable_bathymetry_1d.jl
+++ b/src/equations/bbm_bbm_variable_bathymetry_1d.jl
@@ -190,19 +190,21 @@ function rhs!(du_ode, u_ode, t, mesh, equations::BBMBBMVariableEquations1D,
 
     if solver.D1 isa PeriodicDerivativeOperator ||
        solver.D1 isa UniformPeriodicCoupledOperator
-        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1 * (D .* v + eta .* v)
-        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1 * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:]=-solver.D1 * (D .* v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:]=-solver.D1 *
+                                              (equations.gravity * eta + 0.5 * v .^ 2)
     elseif solver.D1 isa PeriodicUpwindOperators
-        @timeit timer() "deta hyperbolic" deta[:] = -solver.D1.minus * (D .* v + eta .* v)
-        @timeit timer() "dv hyperbolic" dv[:] = -solver.D1.plus * (equations.gravity * eta + 0.5 * v .^ 2)
+        @timeit timer() "deta hyperbolic" deta[:]=-solver.D1.minus * (D .* v + eta .* v)
+        @timeit timer() "dv hyperbolic" dv[:]=-solver.D1.plus *
+                                              (equations.gravity * eta + 0.5 * v .^ 2)
     else
         @error "unknown type of first-derivative operator"
     end
 
     @timeit timer() "source terms" calc_sources!(dq, q, t, source_terms, equations, solver)
 
-    @timeit timer() "deta elliptic" deta[:] = invImDKD * deta
-    @timeit timer() "dv elliptic" dv[:] = invImD2K * dv
+    @timeit timer() "deta elliptic" deta[:]=invImDKD * deta
+    @timeit timer() "dv elliptic" dv[:]=invImD2K * dv
 
     return nothing
 end

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -188,7 +188,7 @@ function rhs!(du_ode, u_ode, t, mesh, equations::SvaerdKalischEquations1D,
         hv = h .* v
 
         if solver.D1 isa PeriodicDerivativeOperator ||
-        solver.D1 isa UniformPeriodicCoupledOperator
+           solver.D1 isa UniformPeriodicCoupledOperator
             D1eta = D1_central * eta
             D1v = D1_central * v
             tmp1 = alpha_hat .* (D1_central * (alpha_hat .* D1eta))
@@ -213,10 +213,10 @@ function rhs!(du_ode, u_ode, t, mesh, equations::SvaerdKalischEquations1D,
     # split form
     @timeit timer() "dv hyperbolic" begin
         dv[:] = -(0.5 * (D1_central * (hv .* v) + hv .* D1v - v .* (D1_central * hv)) +
-                equations.gravity * h .* D1eta +
-                0.5 * (vD1y - D1vy - yD1v) -
-                0.5 * D1_central * (gamma_hat .* (solver.D2 * v)) -
-                0.5 * solver.D2 * (gamma_hat .* D1v))
+                  equations.gravity * h .* D1eta +
+                  0.5 * (vD1y - D1vy - yD1v) -
+                  0.5 * D1_central * (gamma_hat .* (solver.D2 * v)) -
+                  0.5 * solver.D2 * (gamma_hat .* D1v))
     end
 
     # no split form

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -203,9 +203,8 @@ end
 function rhs!(du_ode, u_ode, semi::Semidiscretization, t)
     @unpack mesh, equations, initial_condition, boundary_conditions, solver, source_terms, cache = semi
 
-    rhs!(du_ode, u_ode, t, mesh, equations, initial_condition, boundary_conditions,
-         source_terms,
-         solver, cache)
+    @timeit timer() "rhs!" rhs!(du_ode, u_ode, t, mesh, equations, initial_condition, boundary_conditions,
+                                source_terms, solver, cache)
 
     return nothing
 end

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -203,8 +203,8 @@ end
 function rhs!(du_ode, u_ode, semi::Semidiscretization, t)
     @unpack mesh, equations, initial_condition, boundary_conditions, solver, source_terms, cache = semi
 
-    @timeit timer() "rhs!" rhs!(du_ode, u_ode, t, mesh, equations, initial_condition, boundary_conditions,
-                                source_terms, solver, cache)
+    @timeit timer() "rhs!" rhs!(du_ode, u_ode, t, mesh, equations, initial_condition,
+                                boundary_conditions, source_terms, solver, cache)
 
     return nothing
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -311,6 +311,12 @@ function extract_initial_N(example, kwargs)
     end
 end
 
+# Store main timer for global timing of functions
+const main_timer = TimerOutput()
+
+# Always call timer() to hide implementation details
+timer() = main_timer
+
 """
     @autoinfiltrate
     @autoinfiltrate condition::Bool

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -214,6 +214,13 @@ using SparseArrays: sparse, SparseMatrixCSC
         @test_nowarn display(relaxation_callback)
     end
 
+    @testset "SummaryCallback" begin
+        summary_callback = SummaryCallback()
+        @test_nowarn print(summary_callback)
+        @test_nowarn display(summary_callback)
+        @test_nowarn summary_callback()
+    end
+
     @testset "util" begin
         @test_nowarn get_examples()
         @test_nowarn trixi_include(default_example(), tspan = (0.0, 0.1))


### PR DESCRIPTION
Adds a `SummaryCallback` similar to Trixi.jl that prints the timings and allocations for the different parts of the simulation using TimerOutputs.jl. Unlike Trixi.jl, the `SummaryCallback` does not print anything at the beginning of a simulation and the output from TimerOutputs.jl is always printed at the end of a simulation without the need to manually call the callback.

Closes #45.