### PR TITLE
Use `Remotes.GitHub` when building docs to show link to repo in navbar

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -8,7 +8,7 @@ DocMeta.setdocmeta!(DispersiveShallowWater, :DocTestSetup, :(using DispersiveSha
 makedocs(;
          modules = [DispersiveShallowWater],
          authors = "Joshua Lampert <joshua.lampert@uni-hamburg.de>",
-         repo = "https://github.com/JoshuaLampert/DispersiveShallowWater.jl/blob/{commit}{path}#{line}",
+         repo = Remotes.GitHub("JoshuaLampert", "DispersiveShallowWater.jl"),
          sitename = "DispersiveShallowWater.jl",
          format = Documenter.HTML(;
                                   prettyurls = get(ENV, "CI", "false") == "true",


### PR DESCRIPTION
There are [warnings when building the docs](https://github.com/JoshuaLampert/DispersiveShallowWater.jl/actions/runs/7667277312/job/20896776104#step:7:18) because Documenter.jl is unable to determine the repo URL. Using `Remotes.GitHub` should fix this so that the link to the repo is shown in the upper right in the documentation.