### PR TITLE
Downgrade action moved

### DIFF
--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -48,9 +48,10 @@ jobs:
           arch: ${{ matrix.arch }}
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
       - uses: julia-actions/cache@v1
-      - uses: cjdoris/julia-downgrade-compat-action@v1
+      - uses: julia-actions/julia-downgrade-compat@v1
         with:
           skip: LinearAlgebra,Printf,SparseArrays
+          projects: ., test
       - uses: julia-actions/julia-buildpkg@v1
         env:
           PYTHON: ""

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -9,7 +9,7 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 [compat]
 Aqua = "0.7, 0.8"
 OrdinaryDiffEq = "6.49.1"
-Plots = "1.16"
+Plots = "1.23"
 SparseArrays = "1"
 SummationByPartsOperators = "0.5.41"
 Test = "1"


### PR DESCRIPTION
The downgrade CI action moved to the [julia-action org](https://github.com/julia-actions/julia-downgrade-compat). With version v1.1.0 it also allows to downgrade the `test/Project.toml`.