### PR TITLE
Fix initial condition for manufactured solution (Svärd-Kalisch equations)

### DIFF
--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -94,7 +94,8 @@ function initial_condition_manufactured(x, t,
                                         mesh)
     eta = exp(t) * cospi(2 * (x - 2 * t))
     v = exp(t / 2) * sinpi(2 * (x - t / 2))
-    D = 5 + 2 * cospi(2 * x)
+    b = -5 - 2 * cospi(2 * x)
+    D = equations.eta0 - b
     return SVector(eta, v, D)
 end
 


### PR DESCRIPTION
In #91 I forgot to adjust the initial condition for the manufactured solution for the Svärd-Kalisch equations. It only worked for $\eta_0 = 0$. Now this is fixed and should work for general $\eta_0$.