### PR TITLE
Add test using ExplicitImports.jl

### DIFF
--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -1,16 +1,16 @@
 module DispersiveShallowWater
 
-using DiffEqBase
-using Interpolations
-using LinearAlgebra: mul!, ldiv!, factorize, I, Diagonal
-using PolynomialBases
+using DiffEqBase: DiffEqBase, SciMLBase, terminate!
+using Interpolations: Interpolations, linear_interpolation
+using LinearAlgebra: mul!, I, Diagonal
+using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf
-using RecipesBase
+using RecipesBase: RecipesBase, @recipe, @series
 using Reexport: @reexport
 using Roots: AlefeldPotraShi, find_zero
 
-using SciMLBase: CallbackSet, DiscreteCallback, ODEProblem, ODESolution
-import SciMLBase: get_tmp_cache, u_modified!
+using SciMLBase: DiscreteCallback, ODEProblem, ODESolution
+import SciMLBase: u_modified!
 
 @reexport using StaticArrays: SVector
 using SimpleUnPack: @unpack

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+ExplicitImports = "7d51a73a-1435-4ff3-83d9-f097790105c7"
 OrdinaryDiffEq = "1dea7af3-3e70-54e6-95c3-0bf5283fa5ed"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,7 +1,7 @@
 module TestAqua
 
 using Aqua
-using ExplicitImports
+using ExplicitImports: check_no_implicit_imports, check_no_stale_explicit_imports
 using Test
 using DispersiveShallowWater
 

--- a/test/test_aqua.jl
+++ b/test/test_aqua.jl
@@ -1,12 +1,15 @@
 module TestAqua
 
 using Aqua
+using ExplicitImports
 using Test
 using DispersiveShallowWater
 
 @testset "Aqua.jl" begin
     Aqua.test_all(DispersiveShallowWater,
                   ambiguities = false)
+    @test isnothing(check_no_implicit_imports(DispersiveShallowWater))
+    @test isnothing(check_no_stale_explicit_imports(DispersiveShallowWater))
 end
 
 end #module 


### PR DESCRIPTION
With https://github.com/ericphanson/ExplicitImports.jl there exists a tool to avoid implicit imports and avoid the existence of unused imports. I updated the imports accordingly and added a regression test. I put the test next to the Aqua tests since this is kind of similar.