### PR TITLE
Factorize matrix for `SvaerdKalischEquations1D`

### DIFF
--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -3,7 +3,7 @@ module DispersiveShallowWater
 using BandedMatrices: BandedMatrix
 using DiffEqBase: DiffEqBase, SciMLBase, terminate!
 using Interpolations: Interpolations, linear_interpolation
-using LinearAlgebra: mul!, ldiv!, I, Diagonal, diag, lu
+using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag, lu, cholesky, cholesky!
 using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf
 using RecipesBase: RecipesBase, @recipe, @series

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -241,11 +241,15 @@ function rhs!(du_ode, u_ode, t, mesh, equations::SvaerdKalischEquations1D,
 
     # split form
     @timeit timer() "dv hyperbolic" begin
-        dv[:] = -(0.5 * (D1_central * (hv .* v) .+ hv .* D1v .- v .* (D1_central * hv)) .+
-                  equations.gravity * h .* D1eta .+
-                  0.5 * (vD1y .- D1vy .- yD1v) .-
-                  0.5 * D1_central * (gamma_hat .* (solver.D2 * v)) .-
-                  0.5 * solver.D2 * (gamma_hat .* D1v))
+        D1_hv = D1_central * hv
+        D1_hv2 = D1_central * (hv .* v)
+        D1_gamma_hat_D2_v = D1_central * (gamma_hat .* (solver.D2 * v))
+        D2_gamma_hat_D1_v = solver.D2 * (gamma_hat .* D1v)
+        @. dv = -(0.5 * (D1_hv2 + hv * D1v - v * D1_hv) +
+                  equations.gravity * h * D1eta +
+                  0.5 * (vD1y - D1vy - yD1v) -
+                  0.5 * D1_gamma_hat_D2_v -
+                  0.5 * D2_gamma_hat_D1_v)
     end
 
     # no split form

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -241,10 +241,10 @@ function rhs!(du_ode, u_ode, t, mesh, equations::SvaerdKalischEquations1D,
 
     # split form
     @timeit timer() "dv hyperbolic" begin
-        dv[:] = -(0.5 * (D1_central * (hv .* v) + hv .* D1v - v .* (D1_central * hv)) +
-                  equations.gravity * h .* D1eta +
-                  0.5 * (vD1y - D1vy - yD1v) -
-                  0.5 * D1_central * (gamma_hat .* (solver.D2 * v)) -
+        dv[:] = -(0.5 * (D1_central * (hv .* v) .+ hv .* D1v .- v .* (D1_central * hv)) .+
+                  equations.gravity * h .* D1eta .+
+                  0.5 * (vD1y .- D1vy .- yD1v) .-
+                  0.5 * D1_central * (gamma_hat .* (solver.D2 * v)) .-
                   0.5 * solver.D2 * (gamma_hat .* D1v))
     end
 

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -188,7 +188,7 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
     else
         @error "unknown type of first-derivative operator: $(typeof(solver.D1))"
     end
-    factorization = cholesky(Diagonal(ones(nnodes(mesh))) - D1betaD1)
+    factorization = cholesky(Symmetric(Diagonal(ones(nnodes(mesh))) - D1betaD1))
     return (factorization = factorization, D1betaD1 = D1betaD1, D = D, h = h, hv = hv,
             alpha_hat = alpha_hat, beta_hat = beta_hat, gamma_hat = gamma_hat,
             tmp2 = tmp2, D1_central = D1_central, D1 = solver.D1)

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -201,7 +201,7 @@ end
 function rhs!(du_ode, u_ode, t, mesh, equations::SvaerdKalischEquations1D,
               initial_condition, ::BoundaryConditionPeriodic, source_terms,
               solver, cache)
-    @unpack factorization, D1betaD1, D, h, hv, alpha_hat, beta_hat, gamma_hat, tmp1, tmp2, D1_central = cache
+    @unpack factorization, D1betaD1, D, h, hv, alpha_hat, gamma_hat, tmp1, tmp2, D1_central = cache
     q = wrap_array(u_ode, mesh, equations, solver)
     dq = wrap_array(du_ode, mesh, equations, solver)
 
@@ -213,8 +213,8 @@ function rhs!(du_ode, u_ode, t, mesh, equations::SvaerdKalischEquations1D,
     fill!(dD, zero(eltype(dD)))
 
     @timeit timer() "deta hyperbolic" begin
-        h = eta .+ D .- equations.eta0
-        hv = h .* v
+        @. h = eta + D - equations.eta0
+        @. hv = h * v
 
         if solver.D1 isa PeriodicDerivativeOperator ||
            solver.D1 isa UniformPeriodicCoupledOperator

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -190,7 +190,7 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
     end
     factorization = cholesky(Symmetric(Diagonal(ones(nnodes(mesh))) - D1betaD1))
     return (factorization = factorization, D1betaD1 = D1betaD1, D = D, h = h, hv = hv,
-            alpha_hat = alpha_hat, beta_hat = beta_hat, gamma_hat = gamma_hat,
+            alpha_hat = alpha_hat, gamma_hat = gamma_hat,
             tmp2 = tmp2, D1_central = D1_central, D1 = solver.D1)
 end
 

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -4,18 +4,16 @@ using Test
 using DispersiveShallowWater
 using Plots
 
-@testset "Unit tests" begin
-    @testset "Visualization" begin
-        trixi_include(@__MODULE__, default_example(), tspan = (0.0, 1.0))
-        @test_nowarn plot(semi => sol)
-        @test_nowarn plot!(semi => sol, plot_initial = true)
-        @test_nowarn plot(semi, sol, conversion = prim2cons, plot_bathymetry = false)
-        @test_nowarn plot(semi => sol, 0.0)
-        @test_nowarn plot(semi, sol, 0.0, conversion = prim2cons)
-        @test_nowarn plot(analysis_callback)
-        @test_nowarn plot(analysis_callback, what = (:errors,))
-        @test_nowarn plot(analysis_callback, what = (:integrals, :errors))
-    end
+@testset "Visualization" begin
+    trixi_include(@__MODULE__, default_example(), tspan = (0.0, 1.0))
+    @test_nowarn plot(semi => sol)
+    @test_nowarn plot!(semi => sol, plot_initial = true)
+    @test_nowarn plot(semi, sol, conversion = prim2cons, plot_bathymetry = false)
+    @test_nowarn plot(semi => sol, 0.0)
+    @test_nowarn plot(semi, sol, 0.0, conversion = prim2cons)
+    @test_nowarn plot(analysis_callback)
+    @test_nowarn plot(analysis_callback, what = (:errors,))
+    @test_nowarn plot(analysis_callback, what = (:integrals, :errors))
 end
 
 end # module


### PR DESCRIPTION
Closes #107. Let's see if CI is happy with the `cholesky` decomposition this time. It is significantly faster and less allocating than `lu`. Since we know that `hmD1betaD1` is sparse since `D1betaD1` is constructed to be sparse, I only implemented the first branch in your proposal https://github.com/JoshuaLampert/DispersiveShallowWater.jl/issues/107#issuecomment-2127693468, @ranocha.

Result of `julia> include("examples/svaerd_kalisch_1d/svaerd_kalisch_1d_dingemans.jl");` for `main`:
```julia
──────────────────────────────────────────────────────────────────────────────
        DispersiveSWE                 Time                    Allocations      
                             ───────────────────────   ────────────────────────
      Tot / % measured:           2.34s /  99.4%           3.61GiB /  99.8%    

 Section             ncalls     time    %tot     avg     alloc    %tot      avg
 ──────────────────────────────────────────────────────────────────────────────
 rhs!                 5.16k    2.31s   99.2%   448μs   3.59GiB   99.7%   730KiB
   dv elliptic        5.16k    1.38s   59.4%   268μs   2.77GiB   76.9%   563KiB
   dv hyperbolic      5.16k    865ms   37.1%   168μs    590MiB   16.0%   117KiB
   deta hyperbolic    5.16k   54.8ms    2.3%  10.6μs    250MiB    6.8%  49.5KiB
   ~rhs!~             5.16k   8.03ms    0.3%  1.55μs    816KiB    0.0%     162B
   source terms       5.16k    381μs    0.0%  73.7ns     0.00B    0.0%    0.00B
 analyze solution        86   17.6ms    0.8%   205μs   10.0MiB    0.3%   119KiB
 ──────────────────────────────────────────────────────────────────────────────
```

and this branch (note that I added some `@timeit` statements to have a better overview):
```julia
────────────────────────────────────────────────────────────────────────────────────
           DispersiveSWE                    Time                    Allocations      
                                   ───────────────────────   ────────────────────────
         Tot / % measured:              1.61s /  99.2%           2.43GiB /  99.6%    

 Section                   ncalls     time    %tot     avg     alloc    %tot      avg
 ────────────────────────────────────────────────────────────────────────────────────
 rhs!                       5.16k    1.58s   99.0%   306μs   2.41GiB   99.6%   489KiB
   dv hyperbolic            5.16k    873ms   54.7%   169μs    590MiB   23.8%   117KiB
   dv elliptic              5.16k    641ms   40.1%   124μs   1.59GiB   65.6%   322KiB
     cholesky!              5.16k    478ms   29.9%  92.6μs   0.97GiB   40.1%   197KiB
     solve linear system    5.16k   82.3ms    5.2%  15.9μs    144MiB    5.8%  28.6KiB
     set hmD1betaD1         5.16k   75.5ms    4.7%  14.6μs    488MiB   19.7%  96.9KiB
     set tmp1               5.16k   2.49ms    0.2%   483ns     0.00B    0.0%    0.00B
     ~dv elliptic~          5.16k   2.35ms    0.1%   456ns   2.94KiB    0.0%    0.58B
   deta hyperbolic          5.16k   60.7ms    3.8%  11.7μs    250MiB   10.1%  49.5KiB
   ~rhs!~                   5.16k   5.47ms    0.3%  1.06μs    810KiB    0.0%     161B
   source terms             5.16k    403μs    0.0%  78.1ns     0.00B    0.0%    0.00B
 analyze solution              86   15.8ms    1.0%   184μs   10.0MiB    0.4%   119KiB
 ────────────────────────────────────────────────────────────────────────────────────
```

`cholesky!` still allocates more than I would have hoped, but I think there is not much we can do against, right? But overall this is a nice speedup.