### PR TITLE
Run CI on Julia v1.10

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -44,7 +44,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '1.10'
         os:
           - ubuntu-latest
           - macos-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -51,6 +51,10 @@ jobs:
           - windows-latest
         arch:
           - x64
+        include:
+          - version: '1.9'
+            os: ubuntu-latest
+            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2


### PR DESCRIPTION
Since Julia v1.11 will be out probably soon and v1.10 will be the new LTS, I would like to run CI also on v1.10. 