### PR TITLE
Simplify setting all files in subdirectory in docs

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -3,30 +3,12 @@ using DispersiveShallowWater
 using TrixiBase
 using Changelog: Changelog
 
-# Dynamically replace all files in subdirectories of the source directory to include all files in these subdirectories
+# Dynamically set all files in subdirectories of the source directory to include all files in these subdirectories
 # This way they don't need to be listed explicitly
-EQUATIONS_FILES_TO_BE_INSERTED = joinpath.(Ref("equations"),
-                                           readdir(joinpath(dirname(@__DIR__), "src",
-                                                            "equations")))
-CALLBACKS_STEP_FILES_TO_BE_INSERTED = joinpath.(Ref("callbacks_step"),
-                                                readdir(joinpath(dirname(@__DIR__), "src",
-                                                                 "callbacks_step")))
-
-ref_path = joinpath(@__DIR__, "src", "ref.md")
-lines = readlines(ref_path)
-open(ref_path, "w") do io
-    for line in lines
-        if contains(line, "EQUATIONS_FILES_TO_BE_INSERTED")
-            line = replace(line,
-                           "EQUATIONS_FILES_TO_BE_INSERTED" => EQUATIONS_FILES_TO_BE_INSERTED)
-        end
-        if contains(line, "CALLBACKS_STEP_FILES_TO_BE_INSERTED")
-            line = replace(line,
-                           "CALLBACKS_STEP_FILES_TO_BE_INSERTED" => CALLBACKS_STEP_FILES_TO_BE_INSERTED)
-        end
-        println(io, line)
-    end
-end
+EQUATIONS_FILES = joinpath.(Ref("equations"), readdir(joinpath(dirname(@__DIR__), "src",
+                                                               "equations")))
+CALLBACKS_STEP_FILES = joinpath.(Ref("callbacks_step"), readdir(joinpath(dirname(@__DIR__), "src",
+                                                                         "callbacks_step")))
 
 # Define module-wide setups such that the respective modules are available in doctests
 DocMeta.setdocmeta!(DispersiveShallowWater, :DocTestSetup, :(using DispersiveShallowWater);

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -5,10 +5,12 @@ using Changelog: Changelog
 
 # Dynamically set all files in subdirectories of the source directory to include all files in these subdirectories
 # This way they don't need to be listed explicitly
-EQUATIONS_FILES = joinpath.(Ref("equations"), readdir(joinpath(dirname(@__DIR__), "src",
-                                                               "equations")))
-CALLBACKS_STEP_FILES = joinpath.(Ref("callbacks_step"), readdir(joinpath(dirname(@__DIR__), "src",
-                                                                         "callbacks_step")))
+EQUATIONS_FILES = joinpath.(Ref("equations"),
+                            readdir(joinpath(dirname(@__DIR__), "src",
+                                             "equations")))
+CALLBACKS_STEP_FILES = joinpath.(Ref("callbacks_step"),
+                                 readdir(joinpath(dirname(@__DIR__), "src",
+                                                  "callbacks_step")))
 
 # Define module-wide setups such that the respective modules are available in doctests
 DocMeta.setdocmeta!(DispersiveShallowWater, :DocTestSetup, :(using DispersiveShallowWater);

--- a/docs/src/ref.md
+++ b/docs/src/ref.md
@@ -13,7 +13,7 @@ Pages = ["DispersiveShallowWater.jl"]
 
 ```@autodocs
 Modules = [DispersiveShallowWater]
-Pages = EQUATIONS_FILES_TO_BE_INSERTED
+Pages = Main.EQUATIONS_FILES
 ```
 
 ## Mesh
@@ -48,7 +48,7 @@ Pages = ["semidiscretization.jl"]
 
 ```@autodocs
 Modules = [DispersiveShallowWater]
-Pages = CALLBACKS_STEP_FILES_TO_BE_INSERTED
+Pages = Main.CALLBACKS_STEP_FILES
 ```
 
 ## Utilities


### PR DESCRIPTION
I asked the question on Zulip on how to dynamically insert all the files of a subdirectory in the `PAGES` keyword and now got an answer. Seems like we can access the definitions from `make.jl` by prefixing them with `Main.`, which makes this nicer.

Xref https://github.com/JoshuaLampert/DispersiveShallowWater.jl/pull/134#discussion_r1718894042