### PR TITLE
Adapt Svärd-Kalisch equations to Serre-Green-Naghdi equations

### DIFF
--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -298,7 +298,7 @@ function analyze_integrals!(io, current_integrals, i, analysis_integrals::NTuple
     quantity = first(analysis_integrals)
     remaining_quantities = Base.tail(analysis_integrals)
 
-    res = analyze(quantity, q, t, semi)
+    res = analyze!(semi, quantity, q, t)
     current_integrals[i] = res
     @printf(io, " %-12s:", pretty_form_utf(quantity))
     @printf(io, "  % 10.8e", res)
@@ -326,16 +326,7 @@ function (cb::DiscreteCallback{Condition, Affect!})(sol) where {Condition,
     return (; l2 = l2_error, linf = linf_error)
 end
 
-function analyze(quantity, q, t, semi::Semidiscretization)
-    integrate_quantity(q -> quantity(q, semi.equations), q, semi)
-end
-
-# The modified entropy/energy of the Svärd-Kalisch and
-# Serre-Green-Naghdi equations
-# takes the whole `q` for every point in space since it requires
-# the derivative of the velocity `v_x`.
-function analyze(quantity::Union{typeof(energy_total_modified), typeof(entropy_modified)},
-                 q, t, semi::Semidiscretization)
+function analyze!(semi::Semidiscretization, quantity, q, t)
     integrate_quantity!(semi.cache.tmp1, quantity, q, semi)
 end
 

--- a/src/callbacks_step/analysis.jl
+++ b/src/callbacks_step/analysis.jl
@@ -336,7 +336,7 @@ end
 # the derivative of the velocity `v_x`.
 function analyze(quantity::Union{typeof(energy_total_modified), typeof(entropy_modified)},
                  q, t, semi::Semidiscretization)
-    integrate_quantity(quantity, q, semi)
+    integrate_quantity!(semi.cache.tmp1, quantity, q, semi)
 end
 
 pretty_form_utf(::typeof(waterheight_total)) = "∫η"

--- a/src/callbacks_step/relaxation.jl
+++ b/src/callbacks_step/relaxation.jl
@@ -69,15 +69,7 @@ end
 
     function relaxation_functional(q, semi)
         @unpack tmp1 = semi.cache
-        # modified entropy from Svärd-Kalisch equations need to take the whole vector `q` for every point in space
-        if relaxation_callback.invariant isa
-           Union{typeof(energy_total_modified), typeof(entropy_modified)}
-            return integrate_quantity!(tmp1, relaxation_callback.invariant, q, semi)
-        else
-            return integrate_quantity!(tmp1,
-                                       q -> relaxation_callback.invariant(q, semi.equations),
-                                       q, semi)
-        end
+        return integrate_quantity!(tmp1, relaxation_callback.invariant, q, semi)
     end
 
     function convex_combination(gamma, old, new)

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -270,12 +270,20 @@ contributions.
 `q_global` is a vector of the primitive variables at ALL nodes.
 `cache` needs to hold the SBP operators used by the `solver` if non-hydrostatic
 terms are present.
+
+Internally, this function allocates a vector for the output and
+calls [`DispersiveShallowWater.energy_total_modified!`](@ref).
 """
 function energy_total_modified(q_global, equations::AbstractShallowWaterEquations, cache)
     e = similar(q_global.x[begin])
     return energy_total_modified!(e, q_global, equations, cache)
 end
 
+"""
+    energy_total_modified!(e, q_global, equations::AbstractShallowWaterEquations, cache)
+
+In-place version of [`energy_total_modified`](@ref).
+"""
 function energy_total_modified!(e, q_global, equations::AbstractShallowWaterEquations,
                                 cache)
     # `q_global` is an `ArrayPartition` of the primitive variables at all nodes
@@ -300,6 +308,11 @@ Alias for [`energy_total_modified`](@ref).
     return entropy_modified!(e, q_global, equations, cache)
 end
 
+"""
+    entropy_modified!(e, q_global, equations::AbstractShallowWaterEquations, cache)
+
+In-place version of [`entropy_modified`](@ref).
+"""
 @inline entropy_modified!(e, q_global, equations, cache) = energy_total_modified!(e,
                                                                                   q_global,
                                                                                   equations,

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -272,16 +272,19 @@ contributions.
 terms are present.
 """
 function energy_total_modified(q_global, equations::AbstractShallowWaterEquations, cache)
+    e = similar(q_global.x[begin])
+    return energy_total_modified!(e, q_global, equations, cache)
+end
+
+function energy_total_modified!(e, q_global, equations::AbstractShallowWaterEquations, cache)
     # `q_global` is an `ArrayPartition` of the primitive variables at all nodes
     @assert nvariables(equations) == length(q_global.x)
-    # tmp1 is always in the cache
-    @unpack tmp1 = cache
 
     for i in eachindex(q_global.x[begin])
-        tmp1[i] = energy_total(get_node_vars(q_global, equations, i), equations)
+        e[i] = energy_total(get_node_vars(q_global, equations, i), equations)
     end
 
-    return tmp1
+    return e
 end
 
 varnames(::typeof(energy_total_modified), equations) = ("e_modified",)
@@ -294,6 +297,8 @@ Alias for [`energy_total_modified`](@ref).
 @inline function entropy_modified(q_global, equations::AbstractShallowWaterEquations, cache)
     energy_total_modified(q_global, equations, cache)
 end
+
+@inline entropy_modified!(e, q_global, equations, cache) = energy_total_modified!(e, q_global, equations, cache)
 
 varnames(::typeof(entropy_modified), equations) = ("U_modified",)
 

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -276,7 +276,8 @@ function energy_total_modified(q_global, equations::AbstractShallowWaterEquation
     return energy_total_modified!(e, q_global, equations, cache)
 end
 
-function energy_total_modified!(e, q_global, equations::AbstractShallowWaterEquations, cache)
+function energy_total_modified!(e, q_global, equations::AbstractShallowWaterEquations,
+                                cache)
     # `q_global` is an `ArrayPartition` of the primitive variables at all nodes
     @assert nvariables(equations) == length(q_global.x)
 
@@ -298,7 +299,10 @@ Alias for [`energy_total_modified`](@ref).
     energy_total_modified(q_global, equations, cache)
 end
 
-@inline entropy_modified!(e, q_global, equations, cache) = energy_total_modified!(e, q_global, equations, cache)
+@inline entropy_modified!(e, q_global, equations, cache) = energy_total_modified!(e,
+                                                                                  q_global,
+                                                                                  equations,
+                                                                                  cache)
 
 varnames(::typeof(entropy_modified), equations) = ("U_modified",)
 

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -296,7 +296,8 @@ varnames(::typeof(energy_total_modified), equations) = ("e_modified",)
 Alias for [`energy_total_modified`](@ref).
 """
 @inline function entropy_modified(q_global, equations::AbstractShallowWaterEquations, cache)
-    energy_total_modified(q_global, equations, cache)
+    e = similar(q_global.x[begin])
+    return entropy_modified!(e, q_global, equations, cache)
 end
 
 @inline entropy_modified!(e, q_global, equations, cache) = energy_total_modified!(e,

--- a/src/equations/hyperbolic_serre_green_naghdi_1d.jl
+++ b/src/equations/hyperbolic_serre_green_naghdi_1d.jl
@@ -433,7 +433,7 @@ end
 
 # The entropy/energy takes the whole `q` for every point in space
 """
-    energy_total_modified!(q_global, equations::HyperbolicSerreGreenNaghdiEquations1D, cache)
+    DispersiveShallowWater.energy_total_modified!(e, q_global, equations::HyperbolicSerreGreenNaghdiEquations1D, cache)
 
 Return the modified total energy of the primitive variables `q_global` for the
 [`HyperbolicSerreGreenNaghdiEquations1D`](@ref).
@@ -449,6 +449,8 @@ the total modified energy is given by
 ```
 
 `q_global` is a vector of the primitive variables at ALL nodes.
+
+See also [`energy_total_modified`](@ref).
 """
 function energy_total_modified!(e, q_global,
                                 equations::HyperbolicSerreGreenNaghdiEquations1D,

--- a/src/equations/hyperbolic_serre_green_naghdi_1d.jl
+++ b/src/equations/hyperbolic_serre_green_naghdi_1d.jl
@@ -433,7 +433,7 @@ end
 
 # The entropy/energy takes the whole `q` for every point in space
 """
-    energy_total_modified(q_global, equations::HyperbolicSerreGreenNaghdiEquations1D, cache)
+    energy_total_modified!(q_global, equations::HyperbolicSerreGreenNaghdiEquations1D, cache)
 
 Return the modified total energy of the primitive variables `q_global` for the
 [`HyperbolicSerreGreenNaghdiEquations1D`](@ref).
@@ -450,9 +450,9 @@ the total modified energy is given by
 
 `q_global` is a vector of the primitive variables at ALL nodes.
 """
-function energy_total_modified(q_global,
-                               equations::HyperbolicSerreGreenNaghdiEquations1D,
-                               cache)
+function energy_total_modified!(e, q_global,
+                                equations::HyperbolicSerreGreenNaghdiEquations1D,
+                                cache)
     # unpack physical parameters and SBP operator `D1`
     g = gravity_constant(equations)
     (; lambda) = equations
@@ -463,8 +463,6 @@ function energy_total_modified(q_global,
     eta, v, D, w, H = q_global.x
     @.. b = equations.eta0 - D
     @.. h = eta - b
-
-    e = zero(h)
 
     # 1/2 g eta^2 + 1/2 h v^2 + 1/6 h^3 w^2 + λ/6 h (1 - H/h)^2
     @.. e = 1 / 2 * g * eta^2 + 1 / 2 * h * v^2 + 1 / 6 * h * w^2 +

--- a/src/equations/hyperbolic_serre_green_naghdi_1d.jl
+++ b/src/equations/hyperbolic_serre_green_naghdi_1d.jl
@@ -435,7 +435,7 @@ end
 """
     DispersiveShallowWater.energy_total_modified!(e, q_global, equations::HyperbolicSerreGreenNaghdiEquations1D, cache)
 
-Return the modified total energy of the primitive variables `q_global` for the
+Return the modified total energy `e` of the primitive variables `q_global` for the
 [`HyperbolicSerreGreenNaghdiEquations1D`](@ref).
 It contains additional terms compared to the usual [`energy_total`](@ref)
 modeling non-hydrostatic contributions. The `energy_total_modified`

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -43,7 +43,7 @@ approximation, the Serre-Green-Naghdi equations are
     + \frac{1}{2} g (h^2)_x + g h b_x + \frac{1}{2} h (v^2)_x
     + p_x + \frac{3}{2} \frac{p}{h} b_x + \psi b_x &= 0,\\
   p &= \frac{1}{3} h^3 v_{x}^2 - \frac{1}{3} h^3 v v_{xx}
-    + \frac{1}{2} h^2 v (b_x v)_x,
+    + \frac{1}{2} h^2 v (b_x v)_x,\\
   \psi &= \frac{1}{4} h v (b_x v)_x.
 \end{aligned}
 ```
@@ -353,28 +353,6 @@ function assemble_system_matrix!(cache, h, b_x, D1, D1mat,
                                Diagonal(M_h2_bx))
                      -
                      Diagonal(M_h2_bx) * D1mat)
-end
-
-function solve_system_matrix!(dv, system_matrix, rhs,
-                              ::SerreGreenNaghdiEquations1D,
-                              D1, cache)
-    if issparse(system_matrix)
-        (; factorization) = cache
-        cholesky!(factorization, system_matrix; check = false)
-        if issuccess(factorization)
-            scale_by_mass_matrix!(rhs, D1)
-            dv .= factorization \ rhs
-        else
-            # The factorization may fail if the time step is too large
-            # and h becomes negative.
-            fill!(dv, NaN)
-        end
-    else
-        factorization = cholesky!(system_matrix)
-        scale_by_mass_matrix!(rhs, D1)
-        ldiv!(dv, factorization, rhs)
-    end
-    return nothing
 end
 
 # Discretization that conserves
@@ -819,7 +797,7 @@ end
     return equations.eta0 - D
 end
 
-# The entropy/energy takes the whole `q` for every point in space
+# The modified entropy/energy takes the whole `q` for every point in space
 """
     energy_total_modified(q_global, equations::SerreGreenNaghdiEquations1D, cache)
 

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -310,7 +310,7 @@ function create_cache(mesh,
 end
 
 function assemble_system_matrix!(cache, h, D1, D1mat,
-                                 equations::SerreGreenNaghdiEquations1D{BathymetryFlat})
+                                 ::SerreGreenNaghdiEquations1D{BathymetryFlat})
     (; M_h, M_h3_3) = cache
 
     @.. M_h = h

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -827,16 +827,13 @@ function energy_total_modified(q_global,
                                cache)
     # unpack physical parameters and SBP operator `D1`
     g = gravity_constant(equations)
-    (; D1, h, b, v_x) = cache
+    (; D1, h, b, v_x, tmp) = cache
 
     # `q_global` is an `ArrayPartition`. It collects the individual arrays for
     # the total water height `eta = h + b` and the velocity `v`.
     eta, v, D = q_global.x
     @.. b = equations.eta0 - D
     @.. h = eta - b
-
-    N = length(v)
-    e = zeros(eltype(q_global), N)
 
     # 1/2 g eta^2 + 1/2 h v^2 + 1/6 h^3 w^2
     # and + 1/8 h (v b_x)^2 for full bathymetry without mild-slope approximation
@@ -859,10 +856,10 @@ function energy_total_modified(q_global,
         end
     end
 
-    @.. e = 1 / 2 * g * eta^2 + 1 / 2 * h * v^2 + 1 / 6 * h * (-h * v_x + 1.5 * v * b_x)^2
+    @.. tmp = 1 / 2 * g * eta^2 + 1 / 2 * h * v^2 + 1 / 6 * h * (-h * v_x + 1.5 * v * b_x)^2
     if equations.bathymetry_type isa BathymetryVariable
-        @.. e += 1 / 8 * h * (v * b_x)^2
+        @.. tmp += 1 / 8 * h * (v * b_x)^2
     end
 
-    return e
+    return tmp
 end

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -796,7 +796,7 @@ end
 
 # The modified entropy/energy takes the whole `q` for every point in space
 """
-    DispersiveShallowWater.energy_total_modified!(q_global, equations::SerreGreenNaghdiEquations1D, cache)
+    DispersiveShallowWater.energy_total_modified!(e, q_global, equations::SerreGreenNaghdiEquations1D, cache)
 
 Return the modified total energy `e` of the primitive variables `q_global` for the
 [`SerreGreenNaghdiEquations1D`](@ref).

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -57,8 +57,8 @@ References for the Serre-Green-Naghdi system can be found in
   [DOI: 10.1017/S0022112076002425](https://doi.org/10.1017/S0022112076002425)
 
 The semidiscretization implemented here conserves
-- the total water mass (integral of h) as a linear invariant
-- the total momentum (integral of h v) as a nonlinear invariant if the bathymetry is constant
+- the total water mass (integral of ``h``) as a linear invariant
+- the total momentum (integral of ``h v``) as a nonlinear invariant if the bathymetry is constant
 - the total modified energy
 
 for periodic boundary conditions (see Ranocha and Ricchiuto (2024)).

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -822,8 +822,8 @@ For a [`bathymetry_variable`](@ref) the total modified energy has the additional
 `cache` needs to hold the SBP operators used by the `solver`.
 """
 function energy_total_modified!(e, q_global,
-                               equations::SerreGreenNaghdiEquations1D,
-                               cache)
+                                equations::SerreGreenNaghdiEquations1D,
+                                cache)
     # unpack physical parameters and SBP operator `D1`
     g = gravity_constant(equations)
     (; D1, h, b, v_x) = cache

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -561,8 +561,7 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache,
     @trixi_timeit timer() "hyperbolic terms" begin
         # Compute all derivatives required below
         (; h, h_x, v_x, h_hpb_x, b, b_x, hv_x, v2_x,
-        h2_v_vx_x, h_vx_x, p_h, p_x, tmp,
-        M_h_p_h_bx2, M_h3_3, M_h2_bx) = cache
+        h2_v_vx_x, h_vx_x, p_h, p_x, tmp) = cache
         if equations.bathymetry_type isa BathymetryVariable
             (; psi) = cache
         end

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -821,12 +821,12 @@ For a [`bathymetry_variable`](@ref) the total modified energy has the additional
 `q_global` is a vector of the primitive variables at ALL nodes.
 `cache` needs to hold the SBP operators used by the `solver`.
 """
-function energy_total_modified(q_global,
+function energy_total_modified!(e, q_global,
                                equations::SerreGreenNaghdiEquations1D,
                                cache)
     # unpack physical parameters and SBP operator `D1`
     g = gravity_constant(equations)
-    (; D1, h, b, v_x, tmp) = cache
+    (; D1, h, b, v_x) = cache
 
     # `q_global` is an `ArrayPartition`. It collects the individual arrays for
     # the total water height `eta = h + b` and the velocity `v`.
@@ -855,10 +855,10 @@ function energy_total_modified(q_global,
         end
     end
 
-    @.. tmp = 1 / 2 * g * eta^2 + 1 / 2 * h * v^2 + 1 / 6 * h * (-h * v_x + 1.5 * v * b_x)^2
+    @.. e = 1 / 2 * g * eta^2 + 1 / 2 * h * v^2 + 1 / 6 * h * (-h * v_x + 1.5 * v * b_x)^2
     if equations.bathymetry_type isa BathymetryVariable
-        @.. tmp += 1 / 8 * h * (v * b_x)^2
+        @.. e += 1 / 8 * h * (v * b_x)^2
     end
 
-    return tmp
+    return e
 end

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -796,7 +796,7 @@ end
 
 # The modified entropy/energy takes the whole `q` for every point in space
 """
-    energy_total_modified(q_global, equations::SerreGreenNaghdiEquations1D, cache)
+    DispersiveShallowWater.energy_total_modified!(q_global, equations::SerreGreenNaghdiEquations1D, cache)
 
 Return the modified total energy of the primitive variables `q_global` for the
 [`SerreGreenNaghdiEquations1D`](@ref).
@@ -820,6 +820,8 @@ For a [`bathymetry_variable`](@ref) the total modified energy has the additional
 
 `q_global` is a vector of the primitive variables at ALL nodes.
 `cache` needs to hold the SBP operators used by the `solver`.
+
+See also [`energy_total_modified`](@ref).
 """
 function energy_total_modified!(e, q_global,
                                 equations::SerreGreenNaghdiEquations1D,

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -395,7 +395,7 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache, ::BathymetryFla
     @trixi_timeit timer() "hyperbolic terms" begin
         # Compute all derivatives required below
         (; h, b, h_x, v_x, h2_x, hv_x, v2_x, h2_v_vx_x,
-        h_vx_x, p_x, tmp, M_h, M_h3_3) = cache
+        h_vx_x, p_x, tmp) = cache
 
         @.. b = equations.eta0 - D
         @.. h = eta - b
@@ -477,8 +477,7 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache, ::BathymetryFlat
     @trixi_timeit timer() "hyperbolic terms" begin
         # Compute all derivatives required below
         (; h, b, h_x, v_x, v_x_upwind, h2_x, hv_x, v2_x,
-        h2_v_vx_x, h_vx_x, p_x, tmp,
-        M_h, M_h3_3) = cache
+        h2_v_vx_x, h_vx_x, p_x, tmp) = cache
 
         @.. b = equations.eta0 - D
         @.. h = eta - b
@@ -670,8 +669,7 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache,
     @trixi_timeit timer() "hyperbolic terms" begin
         # Compute all derivatives required below
         (; h, h_x, v_x, v_x_upwind, h_hpb_x, b, b_x, hv_x, v2_x,
-        h2_v_vx_x, h_vx_x, p_h, p_0, p_x, tmp,
-        M_h_p_h_bx2, M_h3_3, M_h2_bx) = cache
+        h2_v_vx_x, h_vx_x, p_h, p_0, p_x, tmp) = cache
         if equations.bathymetry_type isa BathymetryVariable
             (; psi) = cache
         end
@@ -784,11 +782,11 @@ end
     return SVector(eta, v, D)
 end
 
-@inline function waterheight_total(q, equations::AbstractSerreGreenNaghdiEquations1D)
+@inline function waterheight_total(q, ::AbstractSerreGreenNaghdiEquations1D)
     return q[1]
 end
 
-@inline function velocity(q, equations::AbstractSerreGreenNaghdiEquations1D)
+@inline function velocity(q, ::AbstractSerreGreenNaghdiEquations1D)
     return q[2]
 end
 
@@ -833,11 +831,9 @@ function energy_total_modified(q_global,
 
     # `q_global` is an `ArrayPartition`. It collects the individual arrays for
     # the total water height `eta = h + b` and the velocity `v`.
-    eta, v = q_global.x
-    let D = q_global.x[3]
-        @.. b = equations.eta0 - D
-        @.. h = eta - b
-    end
+    eta, v, D = q_global.x
+    @.. b = equations.eta0 - D
+    @.. h = eta - b
 
     N = length(v)
     e = zeros(eltype(q_global), N)

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -798,7 +798,7 @@ end
 """
     DispersiveShallowWater.energy_total_modified!(q_global, equations::SerreGreenNaghdiEquations1D, cache)
 
-Return the modified total energy of the primitive variables `q_global` for the
+Return the modified total energy `e` of the primitive variables `q_global` for the
 [`SerreGreenNaghdiEquations1D`](@ref).
 It contains an additional term containing a
 derivative compared to the usual [`energy_total`](@ref) modeling

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -417,10 +417,10 @@ It is given by
 `q_global` is a vector of the primitive variables at ALL nodes.
 `cache` needs to hold the SBP operators used by the `solver`.
 """
-@inline function energy_total_modified(q_global, equations::SvaerdKalischEquations1D, cache)
+@inline function energy_total_modified!(e, q_global, equations::SvaerdKalischEquations1D, cache)
     # unpack physical parameters and SBP operator `D1`
     g = gravity_constant(equations)
-    (; D1, h, b, v_x, beta_hat, tmp1) = cache
+    (; D1, h, b, v_x, beta_hat) = cache
 
     # `q_global` is an `ArrayPartition`. It collects the individual arrays for
     # the total water height `eta = h + b` and the velocity `v`.
@@ -434,6 +434,6 @@ It is given by
         mul!(v_x, D1, v)
     end
 
-    @.. tmp1 = 1 / 2 * g * eta^2 + 1 / 2 * h * v^2 + 1 / 2 * beta_hat * v_x^2
-    return tmp1
+    @.. e = 1 / 2 * g * eta^2 + 1 / 2 * h * v^2 + 1 / 2 * beta_hat * v_x^2
+    return e
 end

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -401,7 +401,7 @@ end
 
 # The modified entropy/energy takes the whole `q` for every point in space
 """
-    energy_total_modified(q_global, equations::SvaerdKalischEquations1D, cache)
+    DispersiveShallowWater.energy_total_modified!(q_global, equations::SvaerdKalischEquations1D, cache)
 
 Return the modified total energy of the primitive variables `q_global` for the
 [`SvaerdKalischEquations1D`](@ref). It contains an additional term containing a
@@ -416,6 +416,8 @@ It is given by
 
 `q_global` is a vector of the primitive variables at ALL nodes.
 `cache` needs to hold the SBP operators used by the `solver`.
+
+See also [`energy_total_modified`](@ref).
 """
 @inline function energy_total_modified!(e, q_global, equations::SvaerdKalischEquations1D,
                                         cache)

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -310,7 +310,7 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
     @trixi_timeit timer() "assemble system matrix" begin
         system_matrix = assemble_system_matrix!(cache, h, D1, D1_central, equations)
     end
-    @trixi_timeit timer() "dv elliptic" begin
+    @trixi_timeit timer() "solving elliptic system" begin
         solve_system_matrix!(dv, system_matrix, dv,
                              equations, D1, cache)
     end

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -417,7 +417,8 @@ It is given by
 `q_global` is a vector of the primitive variables at ALL nodes.
 `cache` needs to hold the SBP operators used by the `solver`.
 """
-@inline function energy_total_modified!(e, q_global, equations::SvaerdKalischEquations1D, cache)
+@inline function energy_total_modified!(e, q_global, equations::SvaerdKalischEquations1D,
+                                        cache)
     # unpack physical parameters and SBP operator `D1`
     g = gravity_constant(equations)
     (; D1, h, b, v_x, beta_hat) = cache

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -237,8 +237,9 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
     end
     factorization = cholesky(system_matrix)
     cache = (; factorization, minus_MD1betaD1, D, h, hv, b, eta_x, v_x,
-    alpha_eta_x_x, y_x, v_y_x, yv_x, vy, vy_x, y_v_x, h_v_x, hv2_x, v_xx, gamma_v_xx_x, gamma_v_x_xx,
-    alpha_hat, beta_hat, gamma_hat, tmp2, D1_central, M, D1, M_h)
+             alpha_eta_x_x, y_x, v_y_x, yv_x, vy, vy_x, y_v_x, h_v_x, hv2_x, v_xx,
+             gamma_v_xx_x, gamma_v_x_xx,
+             alpha_hat, beta_hat, gamma_hat, tmp2, D1_central, M, D1, M_h)
     if D1 isa PeriodicUpwindOperators
         eta_x_upwind = zero(h)
         v_x_upwind = zero(h)

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -3,14 +3,17 @@
                              gravity_constant, eta0 = 0.0, alpha = 0.0,
                              beta = 0.2308939393939394, gamma = 0.04034343434343434)
 
-Dispersive system by Svärd and Kalisch in one spatial dimension with spatially varying bathymetry. The equations are given in conservative variables by
+Dispersive system by Svärd and Kalisch in one spatial dimension. The equations for variable bathymetry
+are given in conservative variables by
 ```math
 \begin{aligned}
   h_t + (hv)_x &= (\hat\alpha(\hat\alpha(h + b)_x)_x)_x,\\
   (hv)_t + (hv^2)_x + gh(h + b)_x &= (\hat\alpha v(\hat\alpha(h + b)_x)_x)_x + (\hat\beta v_x)_{xt} + \frac{1}{2}(\hat\gamma v_x)_{xx} + \frac{1}{2}(\hat\gamma v_{xx})_x,
 \end{aligned}
 ```
-where ``\hat\alpha^2 = \alpha\sqrt{gD}D^2``, ``\hat\beta = \beta D^3``, ``\hat\gamma = \gamma\sqrt{gD}D^3``. The coefficients ``\alpha``, ``\beta`` and ``\gamma`` are provided in dimensionless form and ``D = \eta_0 - b`` is the still-water depth and `eta0` is the still-water surface (lake-at-rest).
+where ``\hat\alpha^2 = \alpha\sqrt{gD}D^2``, ``\hat\beta = \beta D^3``, ``\hat\gamma = \gamma\sqrt{gD}D^3``.
+The coefficients ``\alpha``, ``\beta`` and ``\gamma`` are provided in dimensionless form and ``D = \eta_0 - b`` is the
+still-water depth and `eta0` is the still-water surface (lake-at-rest).
 The equations can be rewritten in primitive variables as
 ```math
 \begin{aligned}
@@ -19,8 +22,11 @@ The equations can be rewritten in primitive variables as
 \end{aligned}
 ```
 The unknown quantities of the Svärd-Kalisch equations are the total water height ``\eta`` and the velocity ``v``.
-The gravitational constant is denoted by `g` and the bottom topography (bathymetry) ``b = \eta_0 - D``. The water height above the bathymetry is therefore given by
+The gravitational constant is denoted by `g` and the bottom topography (bathymetry) ``b = \eta_0 - D``.
+The water height above the bathymetry is therefore given by
 ``h = \eta - \eta_0 + D``.
+
+Currently, the equations only support a general variable bathymetry, see [`bathymetry_variable`](@ref).
 
 `SvärdKalischEquations1D` is an alias for `SvaerdKalischEquations1D`.
 

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -401,9 +401,9 @@ end
 
 # The modified entropy/energy takes the whole `q` for every point in space
 """
-    DispersiveShallowWater.energy_total_modified!(q_global, equations::SvaerdKalischEquations1D, cache)
+    DispersiveShallowWater.energy_total_modified!(e, q_global, equations::SvaerdKalischEquations1D, cache)
 
-Return the modified total energy of the primitive variables `q_global` for the
+Return the modified total energy `e` of the primitive variables `q_global` for the
 [`SvaerdKalischEquations1D`](@ref). It contains an additional term containing a
 derivative compared to the usual [`energy_total`](@ref) modeling
 non-hydrostatic contributions. The `energy_total_modified`

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -26,9 +26,9 @@ The gravitational constant is denoted by `g` and the bottom topography (bathymet
 
 The equations by Svärd and Kalisch are presented and analyzed in Svärd and Kalisch (2023).
 The semidiscretization implemented here conserves
-# - the total water (integral of h) as a linear invariant
-# - the total momentum (integral of h v) as a nonlinear invariant for flat bathymetry
-# - the total modified energy
+- the total water (integral of ``h``) as a linear invariant
+- the total momentum (integral of ``h v``) as a nonlinear invariant for flat bathymetry
+- the total modified energy
 
 for periodic boundary conditions (see Lampert, Ranocha).
 Additionally, it is well-balanced for the lake-at-rest stationary solution, see Lampert and Ranocha (2024).

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -274,7 +274,9 @@ end
 function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
               initial_condition, ::BoundaryConditionPeriodic, source_terms,
               solver, cache)
-    @unpack D, h, hv, b, eta_x, v_x, alpha_eta_x_x, y_x, v_y_x, yv_x, vy, vy_x, y_v_x, h_v_x, hv2_x, v_xx, gamma_v_xx_x, gamma_v_x_xx, alpha_hat, gamma_hat, tmp1, tmp2, D1_central, M, D1 = cache
+    (; D, h, hv, b, eta_x, v_x, alpha_eta_x_x, y_x, v_y_x, yv_x, vy, vy_x,
+    y_v_x, h_v_x, hv2_x, v_xx, gamma_v_xx_x, gamma_v_x_xx, alpha_hat, gamma_hat,
+    tmp1, tmp2, D1_central, M, D1) = cache
 
     g = gravity_constant(equations)
     eta, v = q.x

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -144,6 +144,9 @@ function integrate_quantity!(quantity, func, q, semi::Semidiscretization)
     integrate(quantity, semi)
 end
 
+# Obtain the function, which has an additional `!` appended to the name
+inplace_version(f) = getfield(@__MODULE__, Symbol(string(nameof(f)) * "!"))
+
 # The entropy/energy of the Svärd-Kalisch and Serre-Green-Naghdi equations
 # takes the whole `q` for every point in space since it requires
 # the derivative of the velocity `v_x`.
@@ -151,7 +154,7 @@ function integrate_quantity!(quantity,
                              func::Union{typeof(energy_total_modified),
                                          typeof(entropy_modified)}, q,
                              semi::Semidiscretization)
-    energy_total_modified!(quantity, q, semi.equations, semi.cache)
+    inplace_version(func)(quantity, q, semi.equations, semi.cache)
     integrate(quantity, semi)
 end
 

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -147,18 +147,12 @@ end
 # The entropy/energy of the Svärd-Kalisch and Serre-Green-Naghdi equations
 # takes the whole `q` for every point in space since it requires
 # the derivative of the velocity `v_x`.
-function integrate_quantity(func::Union{typeof(energy_total_modified),
-                                        typeof(entropy_modified)}, q,
-                            semi::Semidiscretization)
-    quantity = func(q, semi.equations, semi.cache)
-    integrate(quantity, semi)
-end
-
 function integrate_quantity!(quantity,
                              func::Union{typeof(energy_total_modified),
                                          typeof(entropy_modified)}, q,
                              semi::Semidiscretization)
-    integrate_quantity(func, q, semi)
+    energy_total_modified!(quantity, q, semi.equations, semi.cache)
+    integrate(quantity, semi)
 end
 
 @inline function mesh_equations_solver(semi::Semidiscretization)

--- a/src/semidiscretization.jl
+++ b/src/semidiscretization.jl
@@ -139,7 +139,7 @@ end
 
 function integrate_quantity!(quantity, func, q, semi::Semidiscretization)
     for i in eachnode(semi)
-        quantity[i] = func(get_node_vars(q, semi.equations, i))
+        quantity[i] = func(get_node_vars(q, semi.equations, i), semi.equations)
     end
     integrate(quantity, semi)
 end

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -114,6 +114,8 @@ using SparseArrays: sparse, SparseMatrixCSC
             prim2cons,
             prim2prim,
             prim2phys,
+            energy_total_modified,
+            entropy_modified,
         ]
         for conversion in conversion_functions
             @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -146,6 +148,9 @@ using SparseArrays: sparse, SparseMatrixCSC
             e_total = @inferred DispersiveShallowWater.integrate_quantity(energy_total,
                                                                           q, semi)
             @test isapprox(e_modified_total, e_total)
+            U_modified = @inferred entropy_modified(q, equations, cache)
+            U_modified_total = @inferred DispersiveShallowWater.integrate(U_modified, semi)
+            @test isapprox(U_modified_total, e_modified_total)
         end
     end
 
@@ -164,6 +169,8 @@ using SparseArrays: sparse, SparseMatrixCSC
             prim2cons,
             prim2prim,
             prim2phys,
+            energy_total_modified,
+            entropy_modified,
         ]
         for conversion in conversion_functions
             @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -196,6 +203,9 @@ using SparseArrays: sparse, SparseMatrixCSC
             e_total = @inferred DispersiveShallowWater.integrate_quantity(energy_total,
                                                                           q, semi)
             @test isapprox(e_modified_total, e_total)
+            U_modified = @inferred entropy_modified(q, equations, cache)
+            U_modified_total = @inferred DispersiveShallowWater.integrate(U_modified, semi)
+            @test isapprox(U_modified_total, e_modified_total)
         end
     end
 
@@ -234,6 +244,27 @@ using SparseArrays: sparse, SparseMatrixCSC
         @test @inferred(still_water_surface(q, equations)) == 0.0
         @test isapprox(@inferred(energy_total(q, equations)), 8740.42)
         @test @inferred(prim2phys(q, equations)) == @inferred(prim2prim(q, equations))
+
+        @testset "energy_total_modified" begin
+            initial_condition = initial_condition_manufactured
+            boundary_conditions = boundary_condition_periodic
+            mesh = @inferred Mesh1D(-1.0, 1.0, 10)
+            solver = Solver(mesh, 4)
+            semi = @inferred Semidiscretization(mesh, equations, initial_condition,
+                                                solver; boundary_conditions)
+            q = @inferred DispersiveShallowWater.compute_coefficients(initial_condition,
+                                                                      0.0, semi)
+            _, _, _, cache = @inferred DispersiveShallowWater.mesh_equations_solver_cache(semi)
+            e_modified = @inferred energy_total_modified(q, equations, cache)
+            e_modified_total = @inferred DispersiveShallowWater.integrate(e_modified, semi)
+            e_total = @inferred DispersiveShallowWater.integrate_quantity(energy_total,
+                                                                          q, semi)
+            @test isapprox(e_modified_total, 1450.0018635214328)
+            @test isapprox(e_total, 7.405000000000001)
+            U_modified = @inferred entropy_modified(q, equations, cache)
+            U_modified_total = @inferred DispersiveShallowWater.integrate(U_modified, semi)
+            @test isapprox(U_modified_total, e_modified_total)
+        end
     end
 
     @testset "SerreGreenNaghdiEquations1D" begin
@@ -251,6 +282,8 @@ using SparseArrays: sparse, SparseMatrixCSC
             prim2cons,
             prim2prim,
             prim2phys,
+            energy_total_modified,
+            entropy_modified,
         ]
         for conversion in conversion_functions
             @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -265,6 +298,27 @@ using SparseArrays: sparse, SparseMatrixCSC
         @test @inferred(discharge(q, equations)) == 84.0
         @test @inferred(still_water_surface(q, equations)) == 0.0
         @test @inferred(prim2phys(q, equations)) == @inferred(prim2prim(q, equations))
+
+        @testset "energy_total_modified" begin
+            initial_condition = initial_condition_convergence_test
+            boundary_conditions = boundary_condition_periodic
+            mesh = @inferred Mesh1D(-1.0, 1.0, 10)
+            solver = Solver(mesh, 4)
+            semi = @inferred Semidiscretization(mesh, equations, initial_condition,
+                                                solver; boundary_conditions)
+            q = @inferred DispersiveShallowWater.compute_coefficients(initial_condition,
+                                                                      0.0, semi)
+            _, _, _, cache = @inferred DispersiveShallowWater.mesh_equations_solver_cache(semi)
+            e_modified = @inferred energy_total_modified(q, equations, cache)
+            e_modified_total = @inferred DispersiveShallowWater.integrate(e_modified, semi)
+            e_total = @inferred DispersiveShallowWater.integrate_quantity(energy_total,
+                                                                          q, semi)
+            @test isapprox(e_modified_total, 14.303587674490101)
+            @test isapprox(e_total, 14.301514636021535)
+            U_modified = @inferred entropy_modified(q, equations, cache)
+            U_modified_total = @inferred DispersiveShallowWater.integrate(U_modified, semi)
+            @test isapprox(U_modified_total, e_modified_total)
+        end
     end
 
     @testset "HyperbolicSerreGreenNaghdiEquations1D" begin
@@ -283,6 +337,8 @@ using SparseArrays: sparse, SparseMatrixCSC
             prim2cons,
             prim2prim,
             prim2phys,
+            energy_total_modified,
+            entropy_modified,
         ]
         for conversion in conversion_functions
             @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -297,6 +353,27 @@ using SparseArrays: sparse, SparseMatrixCSC
         @test @inferred(discharge(q, equations)) == 84.0
         @test @inferred(still_water_surface(q, equations)) == 0.0
         @test @inferred(prim2phys(q, equations)) == [42.0, 2.0, 0.0]
+
+        @testset "energy_total_modified" begin
+            initial_condition = initial_condition_soliton
+            boundary_conditions = boundary_condition_periodic
+            mesh = @inferred Mesh1D(-1.0, 1.0, 10)
+            solver = Solver(mesh, 4)
+            semi = @inferred Semidiscretization(mesh, equations, initial_condition,
+                                                solver; boundary_conditions)
+            q = @inferred DispersiveShallowWater.compute_coefficients(initial_condition,
+                                                                      0.0, semi)
+            _, _, _, cache = @inferred DispersiveShallowWater.mesh_equations_solver_cache(semi)
+            e_modified = @inferred energy_total_modified(q, equations, cache)
+            e_modified_total = @inferred DispersiveShallowWater.integrate(e_modified, semi)
+            e_total = @inferred DispersiveShallowWater.integrate_quantity(energy_total,
+                                                                          q, semi)
+            @test isapprox(e_modified_total, 14.303814990428117)
+            @test isapprox(e_total, 14.301514636021535)
+            U_modified = @inferred entropy_modified(q, equations, cache)
+            U_modified_total = @inferred DispersiveShallowWater.integrate(U_modified, semi)
+            @test isapprox(U_modified_total, e_modified_total)
+        end
     end
 
     @testset "AnalysisCallback" begin

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -143,8 +143,7 @@ using SparseArrays: sparse, SparseMatrixCSC
             _, _, _, cache = @inferred DispersiveShallowWater.mesh_equations_solver_cache(semi)
             e_modified = @inferred energy_total_modified(q, equations, cache)
             e_modified_total = @inferred DispersiveShallowWater.integrate(e_modified, semi)
-            e_total = @inferred DispersiveShallowWater.integrate_quantity(q -> energy_total(q,
-                                                                                            equations),
+            e_total = @inferred DispersiveShallowWater.integrate_quantity(energy_total,
                                                                           q, semi)
             @test isapprox(e_modified_total, e_total)
         end
@@ -194,8 +193,7 @@ using SparseArrays: sparse, SparseMatrixCSC
             _, _, _, cache = @inferred DispersiveShallowWater.mesh_equations_solver_cache(semi)
             e_modified = @inferred energy_total_modified(q, equations, cache)
             e_modified_total = @inferred DispersiveShallowWater.integrate(e_modified, semi)
-            e_total = @inferred DispersiveShallowWater.integrate_quantity(q -> energy_total(q,
-                                                                                            equations),
+            e_total = @inferred DispersiveShallowWater.integrate_quantity(energy_total,
                                                                           q, semi)
             @test isapprox(e_modified_total, e_total)
         end


### PR DESCRIPTION
In this PR I try to make the implementation of the Svärd-Kalisch equations follow a more similar style as in the Serre-Green-Naghdi equations. This includes:

- having a `bathymetry_type` as additional field. Up to now, only a variable bathymetry is implemented (as we had before). It might be reasonable to also add the possibility to have a `bathymetry_flat` and then use the higher-order derivative operators for the dispersive terms (this, however, would require to have a third-derivative operator in the `solver`). I would like to keep this for a separate PR in the future.
- avoid any allocations in the hyperbolic part. I pre-allocated the necessary data structures in `create_cache` and overwrite them in `rhs!` now instead of always allocating them again. Now we have 0 allocations for the hyperbolic part.
- unify comments and docstrings a bit.
- reuse `solve_system_matrix!` from the Serre-Green-Naghdi equations.
- make some smaller fixes and simplification along the way.

Additionally, I avoided the allocations in `energy_total_modified` by reusing `tmp1`. I don't know if this is a good idea on the other hand. This seems dangerous to me since `tmp1` will be changed. This also changes the returned value, right? Should I revert this change and allocate a new vector each time again, @ranocha?