### PR TITLE
Reuse `pretty_form_utf`

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -160,18 +160,8 @@ end
     PlotDataOverTime(semi => sol, x_value, conversion)
 end
 
-function pretty(name)
-    if name == :waterheight_total
-        return "∫η"
-    elseif name == :velocity
-        return "∫v"
-    elseif name in [:discharge, :momentum]
-        return "∫P"
-    elseif name == :entropy
-        return "∫U"
-    elseif name == :entropy_modified
-        return "∫U_mod"
-    elseif name == :l2_error
+function pretty_form_utf(name)
+    if name == :l2_error
         return "L² error"
     elseif name == :linf_error
         return "L∞ error"
@@ -196,9 +186,10 @@ end
 
         for (i, (name, integral)) in enumerate(pairs(ints))
             name in exclude && continue
+            name_function = getfield(@__MODULE__, name)
             @series begin
                 subplot --> subplot
-                label := pretty(name) * " " * label_extension
+                label := pretty_form_utf(name_function) * " " * label_extension
                 title --> "change of invariants"
                 xguide --> "t"
                 yguide --> "change of invariants"
@@ -213,7 +204,7 @@ end
             name in exclude && continue
             @series begin
                 subplot --> subplot
-                label --> pretty(name) * " " * label_extension
+                label --> pretty_form_utf(name) * " " * label_extension
                 title --> "errors"
                 xguide --> "t"
                 yguide --> "sum of errors"


### PR DESCRIPTION
I noticed that we define the pretty printing of some functions twice: Once for the [`AnalysisCallback`](https://github.com/JoshuaLampert/DispersiveShallowWater.jl/blob/e33d981c7e5a82305158608d2dd6841b347f3ccf/src/callbacks_step/analysis.jl#L333) and once in visualization.jl (and forgot, e.g. ,`energy_total_modified` in visualization.jl). In visualization.jl we only have access to the Symbol and not the function since this is what is stored in `integrals(analysis_callback)`, but we can translate it to the function using `getfield(@__MODULE__, name)`. However, most errors ($L^2$, $L^\infty$ and the conservation error) don't have a corresponding function (the lake-at-rest error on the other hand has). Thus, for simplicity, I just kept the current approach for the errors and define a pretty form in visualization.jl for the errors (this means it is redefined for the lake-at-rest error), but reuse the pretty form from the `AnalysisCallback` for the integrals. This means `pretty_form_utf` dispatches a bit strangely on functions and Symbols. I am open for a better suggestion, @ranocha.