### PR TITLE
Use functions from `analysis_integrals`

### DIFF
--- a/src/visualization.jl
+++ b/src/visualization.jl
@@ -186,10 +186,10 @@ end
 
         for (i, (name, integral)) in enumerate(pairs(ints))
             name in exclude && continue
-            name_function = getfield(@__MODULE__, name)
+            quantity = cb.affect!.analysis_integrals[i]
             @series begin
                 subplot --> subplot
-                label := pretty_form_utf(name_function) * " " * label_extension
+                label := pretty_form_utf(quantity) * " " * label_extension
                 title --> "change of invariants"
                 xguide --> "t"
                 yguide --> "change of invariants"

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -7,7 +7,8 @@ using Plots
 @testset "Visualization" begin
     custom_integral(q, equations) = q[1]^2
     DispersiveShallowWater.pretty_form_utf(::typeof(custom_integral)) = "∫η²"
-    trixi_include(@__MODULE__, default_example(), tspan = (0.0, 1.0), extra_analysis_integrals = (waterheight_total, custom_integral))
+    trixi_include(@__MODULE__, default_example(), tspan = (0.0, 1.0),
+                  extra_analysis_integrals = (waterheight_total, custom_integral))
     @test_nowarn plot(semi => sol)
     @test_nowarn plot!(semi => sol, plot_initial = true)
     @test_nowarn plot(semi, sol, conversion = prim2cons, plot_bathymetry = false)

--- a/test/test_visualization.jl
+++ b/test/test_visualization.jl
@@ -5,7 +5,9 @@ using DispersiveShallowWater
 using Plots
 
 @testset "Visualization" begin
-    trixi_include(@__MODULE__, default_example(), tspan = (0.0, 1.0))
+    custom_integral(q, equations) = q[1]^2
+    DispersiveShallowWater.pretty_form_utf(::typeof(custom_integral)) = "∫η²"
+    trixi_include(@__MODULE__, default_example(), tspan = (0.0, 1.0), extra_analysis_integrals = (waterheight_total, custom_integral))
     @test_nowarn plot(semi => sol)
     @test_nowarn plot!(semi => sol, plot_initial = true)
     @test_nowarn plot(semi, sol, conversion = prim2cons, plot_bathymetry = false)


### PR DESCRIPTION
See the discussion in https://github.com/JoshuaLampert/DispersiveShallowWater.jl/pull/151#discussion_r1753177919.
I'm not sure if that's what you had in mind, @ranocha, but this should work, shouldn't it? We know that the functions within `cb.affect!.analysis_integrals` have the same order as the entries of the NamedTuple `ints = integrals(cb)`. So we can just get the functions from there.

TODO:
- [x] Add a test