### PR TITLE
Use latest version of JuliaFormatter

### DIFF
--- a/.github/workflows/Format-check.yml
+++ b/.github/workflows/Format-check.yml
@@ -8,4 +8,4 @@ jobs:
     steps:
       - uses: julia-actions/julia-format@v3
         with:
-          version: '1.0.45' # default '1'
+          version: '1' # default '1'

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -84,7 +84,7 @@ makedocs(;
              "Development" => "development.md",
              "Reference" => [
                  "TrixiBase" => "ref-trixibase.md",
-                 "DispersiveShallowWater" => "ref.md",
+                 "DispersiveShallowWater" => "ref.md"
              ],
              "Changelog" => "changelog.md",
              "Contributing" => "contributing.md",

--- a/test/test_bbm_1d.jl
+++ b/test/test_bbm_1d.jl
@@ -63,7 +63,7 @@ end
 @testitem "bbm_1d_basic with split_form = false" setup=[
     Setup,
     BBMEquation1D,
-    AdditionalImports,
+    AdditionalImports
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "bbm_1d_basic.jl"),
                         tspan=(0.0, 100.0),

--- a/test/test_bbm_bbm_1d.jl
+++ b/test/test_bbm_bbm_1d.jl
@@ -175,7 +175,7 @@ end
 
 @testitem "bbm_bbm_1d_upwind_relaxation with bathymetry_variable" setup=[
     Setup,
-    BBMBBMEquation1D,
+    BBMBBMEquation1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "bbm_bbm_1d_upwind_relaxation.jl"),
                         bathymetry_type=bathymetry_variable,
@@ -268,7 +268,7 @@ end
 @testitem "bbm_bbm_1d_basic_reflecting with bathymetry_flat" setup=[
     Setup,
     BBMBBMEquation1D,
-    AdditionalImports,
+    AdditionalImports
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "bbm_bbm_1d_basic_reflecting.jl"),
                         bathymetry_type=bathymetry_flat,

--- a/test/test_hyperbolic_serre_green_naghdi_1d.jl
+++ b/test/test_hyperbolic_serre_green_naghdi_1d.jl
@@ -4,7 +4,7 @@ end
 
 @testitem "hyperbolic_serre_green_naghdi_soliton.jl" setup=[
     Setup,
-    HyperbolicSerreGreenNaghdiEquations1D,
+    HyperbolicSerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "hyperbolic_serre_green_naghdi_soliton.jl"),
@@ -14,21 +14,21 @@ end
                             0.006508261273448058,
                             0.0,
                             0.024517136865274798,
-                            0.002141907410685252,
+                            0.002141907410685252
                         ],
                         linf=[
                             0.0005088046605401519,
                             0.0036954890877776703,
                             0.0,
                             0.015022422297545818,
-                            0.0013290414555349184,
+                            0.0013290414555349184
                         ],
                         cons_error=[
                             2.7000623958883807e-13,
                             0.00013389587974454997,
                             0.0,
                             0.005963937086921899,
-                            4.502801745331908e-5,
+                            4.502801745331908e-5
                         ],
                         change_entropy_modified=-2.3374946067633573e-7)
 
@@ -37,7 +37,7 @@ end
 
 @testitem "hyperbolic_serre_green_naghdi_soliton.jl with bathymetry_mild_slope" setup=[
     Setup,
-    HyperbolicSerreGreenNaghdiEquations1D,
+    HyperbolicSerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "hyperbolic_serre_green_naghdi_soliton.jl"),
@@ -48,21 +48,21 @@ end
                             0.006508261273448058,
                             0.0,
                             0.024517136865274798,
-                            0.002141907410685252,
+                            0.002141907410685252
                         ],
                         linf=[
                             0.0005088046605401519,
                             0.0036954890877776703,
                             0.0,
                             0.015022422297545818,
-                            0.0013290414555349184,
+                            0.0013290414555349184
                         ],
                         cons_error=[
                             2.7000623958883807e-13,
                             0.00013389587974454997,
                             0.0,
                             0.005963937086921899,
-                            4.502801745331908e-5,
+                            4.502801745331908e-5
                         ],
                         change_entropy_modified=-2.3374946067633573e-7)
 
@@ -71,7 +71,7 @@ end
 
 @testitem "hyperbolic_serre_green_naghdi_soliton_relaxation.jl" setup=[
     Setup,
-    HyperbolicSerreGreenNaghdiEquations1D,
+    HyperbolicSerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "hyperbolic_serre_green_naghdi_soliton_relaxation.jl"),
@@ -81,21 +81,21 @@ end
                             0.006510737539763134,
                             0.0,
                             0.024517447804525746,
-                            0.002141928791106223,
+                            0.002141928791106223
                         ],
                         linf=[
                             0.0005090662088376163,
                             0.0036987746989370907,
                             0.0,
                             0.01502004552088677,
-                            0.0013289272946777064,
+                            0.0013289272946777064
                         ],
                         cons_error=[
                             3.126388037344441e-13,
                             0.00013409338344283483,
                             0.0,
                             0.005963706457799891,
-                            4.504121848469822e-5,
+                            4.504121848469822e-5
                         ],
                         change_entropy_modified=-5.684341886080802e-14,
                         atol=2.0e-10) # to make CI pass
@@ -105,7 +105,7 @@ end
 
 @testitem "hyperbolic_serre_green_naghdi_well_balanced.jl" setup=[
     Setup,
-    HyperbolicSerreGreenNaghdiEquations1D,
+    HyperbolicSerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "hyperbolic_serre_green_naghdi_well_balanced.jl"),
@@ -115,21 +115,21 @@ end
                             4.5636580728083475e-14,
                             4.217312212200215e-15,
                             5.399527148467818e-14,
-                            4.646551952637425e-15,
+                            4.646551952637425e-15
                         ],
                         linf=[
                             3.175237850427948e-14,
                             1.2230280990924922e-13,
                             6.661338147750939e-15,
                             1.2201879375620406e-13,
-                            2.4646951146678475e-14,
+                            2.4646951146678475e-14
                         ],
                         cons_error=[
                             1.509903313490213e-14,
                             1.7256186536178874e-16,
                             2.220446049250313e-15,
                             6.788390857160712e-14,
-                            2.220446049250313e-15,
+                            2.220446049250313e-15
                         ],
                         change_entropy_modified=-3.197442310920451e-14,
                         lake_at_rest=1.833689450281284e-14)
@@ -139,7 +139,7 @@ end
 
 @testitem "hyperbolic_serre_green_naghdi_manufactured.jl" setup=[
     Setup,
-    HyperbolicSerreGreenNaghdiEquations1D,
+    HyperbolicSerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "hyperbolic_serre_green_naghdi_manufactured.jl"),
@@ -149,14 +149,14 @@ end
                             3.9074713552924354e-5,
                             0.0,
                             0.003659648461678621,
-                            0.00020113904201635437,
+                            0.00020113904201635437
                         ],
                         linf=[
                             0.00033469307712019614,
                             8.167556996618863e-5,
                             0.0,
                             0.006470346460325516,
-                            0.0003406400402869991,
+                            0.0003406400402869991
                         ],
                         cons_error=[0.0,
                             1.204145701494186e-5,
@@ -170,7 +170,7 @@ end
 
 @testitem "hyperbolic_serre_green_naghdi_dingemans.jl" setup=[
     Setup,
-    HyperbolicSerreGreenNaghdiEquations1D,
+    HyperbolicSerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "hyperbolic_serre_green_naghdi_dingemans.jl"),
@@ -180,14 +180,14 @@ end
                             0.7376950780256356,
                             3.389954422650516e-15,
                             0.5105085009518094,
-                            0.2270170397315174,
+                            0.2270170397315174
                         ],
                         linf=[
                             0.03631632774349847,
                             0.11854594481576813,
                             3.497202527569243e-15,
                             0.08108200376359903,
-                            0.03645317804157178,
+                            0.03645317804157178
                         ],
                         cons_error=[2.3874235921539366e-12,
                             0.0006849904339648783,
@@ -202,7 +202,7 @@ end
 
 @testitem "hyperbolic_serre_green_naghdi_conservation.jl" setup=[
     Setup,
-    HyperbolicSerreGreenNaghdiEquations1D,
+    HyperbolicSerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "hyperbolic_serre_green_naghdi_conservation.jl"),
@@ -211,14 +211,14 @@ end
                             2.367812627978776,
                             3.565537895102537e-14,
                             0.8095219703329345,
-                            1.3613680507825028,
+                            1.3613680507825028
                         ],
                         linf=[
                             1.0010230791351136,
                             0.7870081638593119,
                             9.325873406851315e-15,
                             0.24169078965789928,
-                            1.0010090485188015,
+                            1.0010090485188015
                         ],
                         cons_error=[6.230038707144558e-11,
                             0.00029618251641450044,

--- a/test/test_serre_green_naghdi_1d.jl
+++ b/test/test_serre_green_naghdi_1d.jl
@@ -17,7 +17,7 @@ end
 
 @testitem "serre_green_naghdi_soliton.jl with bathymetry_mild_slope" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same values as serre_green_naghdi_soliton.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -35,7 +35,7 @@ end
 
 @testitem "serre_green_naghdi_soliton.jl with bathymetry_variable" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same values as serre_green_naghdi_soliton.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -66,7 +66,7 @@ end
 
 @testitem "serre_green_naghdi_soliton_fourier.jl with bathymetry_mild_slope" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same values as serre_green_naghdi_soliton_fourier.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -84,7 +84,7 @@ end
 
 @testitem "serre_green_naghdi_soliton_fourier.jl with bathymetry_variable" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same values as serre_green_naghdi_soliton_fourier.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -115,7 +115,7 @@ end
 
 @testitem "serre_green_naghdi_soliton_upwind.jl with bathymetry_mild_slope" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same as serre_green_naghdi_soliton_upwind.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -133,7 +133,7 @@ end
 
 @testitem "serre_green_naghdi_soliton_upwind.jl with bathymetry_variable" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same as serre_green_naghdi_soliton_upwind.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -151,7 +151,7 @@ end
 
 @testitem "serre_green_naghdi_soliton_relaxation.jl" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "serre_green_naghdi_soliton_relaxation.jl"),
@@ -167,7 +167,7 @@ end
 
 @testitem "serre_green_naghdi_soliton_relaxation.jl with bathymetry_mild_slope" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same as serre_green_naghdi_soliton_relaxation.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -185,7 +185,7 @@ end
 
 @testitem "serre_green_naghdi_soliton_relaxation.jl with bathymetry_variable" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     # same as serre_green_naghdi_soliton_relaxation.jl but with more allocations
     @test_trixi_include(joinpath(EXAMPLES_DIR,
@@ -218,7 +218,7 @@ end
 
 @testitem "serre_green_naghdi_well_balanced.jl with bathymetry_mild_slope" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "serre_green_naghdi_well_balanced.jl"),
@@ -251,7 +251,7 @@ end
 
 @testitem "serre_green_naghdi_dingemans.jl with bathymetry_mild_slope" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "serre_green_naghdi_dingemans.jl"),
@@ -283,7 +283,7 @@ end
 
 @testitem "serre_green_naghdi_conservation.jl with bathymetry_mild_slope" setup=[
     Setup,
-    SerreGreenNaghdiEquations1D,
+    SerreGreenNaghdiEquations1D
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "serre_green_naghdi_conservation.jl"),

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -20,7 +20,7 @@ end
 @testitem "svaerd_kalisch_1d_dingemans" setup=[
     Setup,
     SvaerdKalischEquations1D,
-    AdditionalImports,
+    AdditionalImports
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR,
                                  "svaerd_kalisch_1d_dingemans.jl"),

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -105,7 +105,7 @@ end
         prim2phys,
         energy_total_modified,
         entropy_modified,
-        hamiltonian,
+        hamiltonian
     ]
     for conversion in conversion_functions
         @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -155,7 +155,7 @@ end
         prim2prim,
         prim2phys,
         energy_total_modified,
-        entropy_modified,
+        entropy_modified
     ]
     for conversion in conversion_functions
         @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -213,7 +213,7 @@ end
         prim2prim,
         prim2phys,
         energy_total_modified,
-        entropy_modified,
+        entropy_modified
     ]
     for conversion in conversion_functions
         @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -268,7 +268,7 @@ end
         prim2prim,
         prim2phys,
         energy_total_modified,
-        entropy_modified,
+        entropy_modified
     ]
     for conversion in conversion_functions
         @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple
@@ -323,7 +323,7 @@ end
         prim2prim,
         prim2phys,
         energy_total_modified,
-        entropy_modified,
+        entropy_modified
     ]
     for conversion in conversion_functions
         @test DispersiveShallowWater.varnames(conversion, equations) isa Tuple


### PR DESCRIPTION
In Trixi.jl we switched to the latest version of JuliaFormatter again, see https://github.com/trixi-framework/Trixi.jl/pull/2071. So let's do this here, too. As in Trixi.jl this leads to removing the trailing commas. I slightly prefer using the latest JuliaFormatter version v1 instead of fixing it to v1.0.60 (the current latest). 