### PR TITLE
Use default `arch` in CI

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -42,7 +42,7 @@ concurrency:
 jobs:
   test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -53,18 +53,14 @@ jobs:
           - ubuntu-latest
           - macos-latest
           - windows-latest
-        arch:
-          - x64
         include:
           - version: '1.9'
             os: ubuntu-latest
-            arch: x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-buildpkg@v1
@@ -80,7 +76,7 @@ jobs:
       - uses: coverallsapp/github-action@v2
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
-          flag-name: run-${{ matrix.os }}-${{ matrix.version }}-${{ matrix.arch }}-${{ github.run_id }}
+          flag-name: run-${{ join(matrix.*, '-') }}
           parallel: true
           path-to-lcov: ./lcov.info
 

--- a/.github/workflows/Downgrade.yml
+++ b/.github/workflows/Downgrade.yml
@@ -27,9 +27,9 @@ jobs:
   downgrade_test:
     if: "!contains(github.event.head_commit.message, 'skip ci')"
     # We could also include the Julia version as in
-    # name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    # name: ${{ matrix.trixi_test }} - ${{ matrix.os }} - Julia ${{ matrix.version }} - ${{ github.event_name }}
     # to be more specific. However, that requires us updating the required CI tests whenever we update Julia.
-    name: Downgrade ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
+    name: Downgrade ${{ matrix.os }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -40,14 +40,11 @@ jobs:
           # - 'nightly'
         os:
           - ubuntu-latest
-        arch:
-          - x64
     steps:
       - uses: actions/checkout@v4
       - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
       - run: julia -e 'using InteractiveUtils; versioninfo(verbose=true)'
       - uses: julia-actions/cache@v2
       - uses: julia-actions/julia-downgrade-compat@v1

--- a/test/test_bbm_1d.jl
+++ b/test/test_bbm_1d.jl
@@ -155,5 +155,5 @@ end
                         change_waterheight=-3.745851908818973e-12,
                         atol=1e-11) # to make CI pass
 
-    @test_allocations(semi, sol, allocs=5_000)
+    @test_allocations(semi, sol, allocs=6_000)
 end

--- a/test/test_bbm_bbm_1d.jl
+++ b/test/test_bbm_bbm_1d.jl
@@ -105,7 +105,8 @@ end
                         change_waterheight=3.9206314028412105e-14,
                         change_velocity=-4.547473508864641e-13,
                         change_entropy=0.0002383147650562023,
-                        atol_ints=1e-10) # to make CI pass
+                        atol=1e-11,
+                        atol_ints=1e-9) # to make CI pass
 
     @test_allocations(semi, sol, allocs=10_000)
 end
@@ -120,6 +121,7 @@ end
                         change_waterheight=6.232593470137382e-13,
                         change_velocity=-4.547473508864641e-13,
                         change_entropy=0.0002383154298968293,
+                        atol=1e-11,
                         atol_ints=1e-10) # to make CI pass
 
     @test_allocations(semi, sol, allocs=10_000)
@@ -222,7 +224,7 @@ end
                         change_waterheight=9.701410286113879e-10,
                         change_velocity=0.5469460962472683,
                         change_entropy=132.10935771957952,
-                        atol=1e-10,
+                        atol=1e-9,
                         atol_ints=1e-10) # to make CI pass
 
     @test_allocations(semi, sol, allocs=1_500)
@@ -244,7 +246,7 @@ end
                         change_velocity=0.5469460993745239,
                         change_entropy=132.10938489083918,
                         atol=1e-7,
-                        atol_ints=1e-10) # to make CI pass
+                        atol_ints=1e-9) # to make CI pass
 
     @test_allocations(semi, sol, allocs=2_000)
 end


### PR DESCRIPTION
There are warnings (e.g., https://github.com/JoshuaLampert/DispersiveShallowWater.jl/actions/runs/12108289323) in the CI runs because we request x64 on a macOS runner with arm64. I propose to simply use the default architecture, i.e. to remove the `arch` argument. For the `flag-name` of the coveralls action I followed the example under https://github.com/coverallsapp/github-action?tab=readme-ov-file#complete-parallel-job-example.