### PR TITLE
Add reflecting boundary conditions for Svärd-Kalisch equations

### DIFF
--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
@@ -42,5 +42,5 @@ analysis_callback = AnalysisCallback(semi; interval = 100,
 callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
-sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,
+sol = solve(ode, Tsit5(), abstol = 1e-12, reltol = 1e-12,
             save_everystep = false, callback = callbacks, saveat = saveat)

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
@@ -1,0 +1,49 @@
+using OrdinaryDiffEqTsit5
+using DispersiveShallowWater
+using SummationByPartsOperators: MattssonNordström2004, derivative_operator
+
+###############################################################################
+# Semidiscretization of the Svärd-Kalisch equations
+
+equations = SvaerdKalischEquations1D(gravity_constant = 1.0, eta0 = 0.0,
+                                     alpha = 0.0, beta = 1 / 3, gamma = 0.0)
+
+initial_condition = initial_condition_manufactured_reflecting
+source_terms = source_terms_manufactured_reflecting
+boundary_conditions = boundary_condition_reflecting
+
+# create homogeneous mesh
+coordinates_min = 0.0
+coordinates_max = 1.0
+N = 512
+mesh = Mesh1D(coordinates_min, coordinates_max, N)
+
+# create solver with SBP operators of accuracy order 4
+accuracy_order = 4
+D1 = derivative_operator(MattssonNordström2004(),
+                         derivative_order = 1, accuracy_order = accuracy_order,
+                         xmin = mesh.xmin, xmax = mesh.xmax, N = mesh.N)
+D2 = derivative_operator(MattssonNordström2004(),
+                         derivative_order = 2, accuracy_order = accuracy_order,
+                         xmin = mesh.xmin, xmax = mesh.xmax, N = mesh.N)
+solver = Solver(D1, D2)
+
+# semidiscretization holds all the necessary data structures for the spatial discretization
+semi = Semidiscretization(mesh, equations, initial_condition, solver,
+                          boundary_conditions = boundary_conditions,
+                          source_terms = source_terms)
+
+###############################################################################
+# Create `ODEProblem` and run the simulation
+tspan = (0.0, 1.0)
+ode = semidiscretize(semi, tspan)
+summary_callback = SummaryCallback()
+analysis_callback = AnalysisCallback(semi; interval = 100,
+                                     extra_analysis_errors = (:conservation_error,),
+                                     extra_analysis_integrals = (waterheight_total,
+                                                                 velocity, entropy))
+callbacks = CallbackSet(analysis_callback, summary_callback)
+
+saveat = range(tspan..., length = 100)
+sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,
+            save_everystep = false, callback = callbacks, saveat = saveat)

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
@@ -4,7 +4,7 @@ using SummationByPartsOperators: MattssonNordström2004, derivative_operator
 
 ###############################################################################
 # Semidiscretization of the Svärd-Kalisch equations
-
+# For reflecting boundary conditions, alpha and gamma need to be 0
 equations = SvaerdKalischEquations1D(gravity_constant = 1.0, eta0 = 0.0,
                                      alpha = 0.0, beta = 1 / 3, gamma = 0.0)
 
@@ -23,10 +23,7 @@ accuracy_order = 4
 D1 = derivative_operator(MattssonNordström2004(),
                          derivative_order = 1, accuracy_order = accuracy_order,
                          xmin = mesh.xmin, xmax = mesh.xmax, N = mesh.N)
-D2 = derivative_operator(MattssonNordström2004(),
-                         derivative_order = 2, accuracy_order = accuracy_order,
-                         xmin = mesh.xmin, xmax = mesh.xmax, N = mesh.N)
-solver = Solver(D1, D2)
+solver = Solver(D1, nothing)
 
 # semidiscretization holds all the necessary data structures for the spatial discretization
 semi = Semidiscretization(mesh, equations, initial_condition, solver,
@@ -41,7 +38,7 @@ summary_callback = SummaryCallback()
 analysis_callback = AnalysisCallback(semi; interval = 100,
                                      extra_analysis_errors = (:conservation_error,),
                                      extra_analysis_integrals = (waterheight_total,
-                                                                 velocity, entropy))
+                                                                 entropy_modified))
 callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)

--- a/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
+++ b/examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl
@@ -42,5 +42,5 @@ analysis_callback = AnalysisCallback(semi; interval = 100,
 callbacks = CallbackSet(analysis_callback, summary_callback)
 
 saveat = range(tspan..., length = 100)
-sol = solve(ode, Tsit5(), abstol = 1e-12, reltol = 1e-12,
+sol = solve(ode, Tsit5(), abstol = 1e-7, reltol = 1e-7,
             save_everystep = false, callback = callbacks, saveat = saveat)

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -20,7 +20,7 @@ using DiffEqBase: DiffEqBase, SciMLBase, terminate!
 using FastBroadcast: @..
 using Interpolations: Interpolations, linear_interpolation
 using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag,
-                     lu, lu!, cholesky, cholesky!, issuccess
+                     lu, cholesky, cholesky!, issuccess
 using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf
 using RecipesBase: RecipesBase, @recipe, @series

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -19,8 +19,8 @@ using BandedMatrices: BandedMatrix
 using DiffEqBase: DiffEqBase, SciMLBase, terminate!
 using FastBroadcast: @..
 using Interpolations: Interpolations, linear_interpolation
-using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag,
-                     lu, cholesky, cholesky!, issuccess
+using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag, lu, cholesky, cholesky!,
+                     issuccess
 using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf
 using RecipesBase: RecipesBase, @recipe, @series

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -19,9 +19,8 @@ using BandedMatrices: BandedMatrix
 using DiffEqBase: DiffEqBase, SciMLBase, terminate!
 using FastBroadcast: @..
 using Interpolations: Interpolations, linear_interpolation
-using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag, lu, lu!, cholesky,
-                     cholesky!,
-                     issuccess
+using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag,
+                     lu, lu!, cholesky, cholesky!, issuccess
 using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf
 using RecipesBase: RecipesBase, @recipe, @series

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -20,7 +20,7 @@ using DiffEqBase: DiffEqBase, SciMLBase, terminate!
 using FastBroadcast: @..
 using Interpolations: Interpolations, linear_interpolation
 using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag,
-                     lu, cholesky, cholesky!, issuccess
+                     lu, lu!, cholesky, cholesky!, issuccess
 using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf
 using RecipesBase: RecipesBase, @recipe, @series

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -19,7 +19,7 @@ using BandedMatrices: BandedMatrix
 using DiffEqBase: DiffEqBase, SciMLBase, terminate!
 using FastBroadcast: @..
 using Interpolations: Interpolations, linear_interpolation
-using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag, lu, cholesky, cholesky!,
+using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag, lu, lu!, cholesky, cholesky!,
                      issuccess
 using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf

--- a/src/DispersiveShallowWater.jl
+++ b/src/DispersiveShallowWater.jl
@@ -19,7 +19,8 @@ using BandedMatrices: BandedMatrix
 using DiffEqBase: DiffEqBase, SciMLBase, terminate!
 using FastBroadcast: @..
 using Interpolations: Interpolations, linear_interpolation
-using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag, lu, lu!, cholesky, cholesky!,
+using LinearAlgebra: mul!, ldiv!, I, Diagonal, Symmetric, diag, lu, lu!, cholesky,
+                     cholesky!,
                      issuccess
 using PolynomialBases: PolynomialBases
 using Printf: @printf, @sprintf

--- a/src/equations/bbm_bbm_1d.jl
+++ b/src/equations/bbm_bbm_1d.jl
@@ -432,7 +432,8 @@ function rhs!(dq, q, t, mesh, equations::BBMBBMEquations1D, initial_condition,
     end
     # energy and mass conservative semidiscretization
     if solver.D1 isa PeriodicDerivativeOperator ||
-       solver.D1 isa UniformPeriodicCoupledOperator
+       solver.D1 isa UniformPeriodicCoupledOperator ||
+       solver.D1 isa FourierDerivativeOperator
         @trixi_timeit timer() "deta hyperbolic" begin
             mul!(deta, solver.D1, tmp1)
         end

--- a/src/equations/bbm_bbm_1d.jl
+++ b/src/equations/bbm_bbm_1d.jl
@@ -338,8 +338,7 @@ function create_cache(mesh, equations::BBMBBMEquations1D{BathymetryFlat},
 
     # homogeneous Neumann boundary conditions
     if solver.D1 isa DerivativeOperator ||
-       solver.D1 isa UniformCoupledOperator ||
-       solver.D1 isa FourierDerivativeOperator
+       solver.D1 isa UniformCoupledOperator
         D1_b = BandedMatrix(solver.D1)
         invImD2n = lu(I + 1 / 6 * D^2 * inv(M) * D1_b' * PdM * D1_b)
     elseif solver.D1 isa UpwindOperators
@@ -382,8 +381,7 @@ function create_cache(mesh, equations::BBMBBMEquations1D,
 
     # homogeneous Neumann boundary conditions
     if solver.D1 isa DerivativeOperator ||
-       solver.D1 isa UniformCoupledOperator ||
-       solver.D1 isa FourierDerivativeOperator
+       solver.D1 isa UniformCoupledOperator
         D1_b = BandedMatrix(solver.D1)
         invImD2n = lu(I + 1 / 6 * inv(M) * D1_b' * PdM * K * D1_b)
     elseif solver.D1 isa UpwindOperators
@@ -434,8 +432,7 @@ function rhs!(dq, q, t, mesh, equations::BBMBBMEquations1D, initial_condition,
     end
     # energy and mass conservative semidiscretization
     if solver.D1 isa PeriodicDerivativeOperator ||
-       solver.D1 isa UniformPeriodicCoupledOperator ||
-       solver.D1 isa FourierDerivativeOperator
+       solver.D1 isa UniformPeriodicCoupledOperator
         @trixi_timeit timer() "deta hyperbolic" begin
             mul!(deta, solver.D1, tmp1)
         end
@@ -501,8 +498,7 @@ function rhs!(dq, q, t, mesh, equations::BBMBBMEquations1D, initial_condition,
     end
     # energy and mass conservative semidiscretization
     if solver.D1 isa DerivativeOperator ||
-       solver.D1 isa UniformCoupledOperator ||
-       solver.D1 isa FourierDerivativeOperator
+       solver.D1 isa UniformCoupledOperator
         @trixi_timeit timer() "deta hyperbolic" begin
             mul!(deta, solver.D1, tmp1)
         end

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -567,7 +567,7 @@ function solve_system_matrix!(dv, system_matrix, rhs,
         if issuccess(factorization)
             scale_by_mass_matrix!(rhs, D1)
             # see https://github.com/JoshuaLampert/DispersiveShallowWater.jl/issues/122
-            dv .= system_matrix \ rhs[2:(end - 1)]
+            dv .= factorization \ rhs[2:(end - 1)]
         else
             # The factorization may fail if the time step is too large
             # and h becomes negative.
@@ -579,13 +579,6 @@ function solve_system_matrix!(dv, system_matrix, rhs,
         ldiv!(dv, factorization, rhs)
     end
     return nothing
-end
-
-# Svärd-Kalisch equations for reflecting boundary conditions uses LU factorization
-function solve_system_matrix_lu!(dv, system_matrix_lu, ::SvaerdKalischEquations1D, cache)
-    (; factorization_lu) = cache
-    lu!(factorization_lu, system_matrix_lu)
-    ldiv!(factorization_lu, dv)
 end
 
 function solve_system_matrix!(dv, system_matrix, ::Union{BBMEquation1D, BBMBBMEquations1D})

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -581,6 +581,13 @@ function solve_system_matrix!(dv, system_matrix, rhs,
     return nothing
 end
 
+# Svärd-Kalisch equations for reflecting boundary conditions uses LU factorization
+function solve_system_matrix!(dv, system_matrix, ::SvaerdKalischEquations1D, cache)
+    (; factorization) = cache
+    lu!(factorization, system_matrix)
+    ldiv!(factorization, dv)
+end
+
 function solve_system_matrix!(dv, system_matrix, ::Union{BBMEquation1D, BBMBBMEquations1D})
     ldiv!(system_matrix, dv)
 end

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -565,9 +565,8 @@ function solve_system_matrix!(dv, system_matrix, rhs,
         (; factorization) = cache
         cholesky!(factorization, system_matrix; check = false)
         if issuccess(factorization)
-            scale_by_mass_matrix!(rhs, D1)
             # see https://github.com/JoshuaLampert/DispersiveShallowWater.jl/issues/122
-            dv .= factorization \ rhs[2:(end - 1)]
+            dv .= factorization \ rhs
         else
             # The factorization may fail if the time step is too large
             # and h becomes negative.
@@ -575,7 +574,6 @@ function solve_system_matrix!(dv, system_matrix, rhs,
         end
     else
         factorization = cholesky!(system_matrix)
-        scale_by_mass_matrix!(rhs, D1)
         ldiv!(dv, factorization, rhs)
     end
     return nothing

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -558,16 +558,16 @@ include("serre_green_naghdi_1d.jl")
 include("hyperbolic_serre_green_naghdi_1d.jl")
 
 function solve_system_matrix!(dv, system_matrix, rhs,
-                              ::Union{SvaerdKalischEquations1D,
-                                      SerreGreenNaghdiEquations1D},
+                              equations::Union{SvaerdKalischEquations1D,
+                                               SerreGreenNaghdiEquations1D},
                               D1, cache, ::BoundaryConditionPeriodic)
     scale_by_mass_matrix!(rhs, D1)
     solve_system_matrix!(dv, system_matrix, rhs, equations, D1, cache)
 end
 
 function solve_system_matrix!(dv, system_matrix, rhs,
-                              ::Union{SvaerdKalischEquations1D,
-                                      SerreGreenNaghdiEquations1D},
+                              equations::Union{SvaerdKalischEquations1D,
+                                               SerreGreenNaghdiEquations1D},
                               D1, cache, ::BoundaryConditionReflecting)
     scale_by_mass_matrix!(rhs, D1)
     solve_system_matrix!(dv, system_matrix, (@view rhs[2:(end - 1)]), equations, D1, cache)

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -570,7 +570,8 @@ function solve_system_matrix!(dv, system_matrix, rhs,
                                                SerreGreenNaghdiEquations1D},
                               D1, cache, ::BoundaryConditionReflecting)
     scale_by_mass_matrix!(rhs, D1)
-    solve_system_matrix!(dv, system_matrix, (@view rhs[(begin + 1):(end - 1)]), equations, D1, cache)
+    solve_system_matrix!(dv, system_matrix, (@view rhs[(begin + 1):(end - 1)]), equations,
+                         D1, cache)
 end
 
 function solve_system_matrix!(dv, system_matrix, rhs,

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -567,7 +567,7 @@ function solve_system_matrix!(dv, system_matrix, rhs,
         if issuccess(factorization)
             scale_by_mass_matrix!(rhs, D1)
             # see https://github.com/JoshuaLampert/DispersiveShallowWater.jl/issues/122
-            dv .= factorization \ rhs
+            dv .= system_matrix \ rhs[2:(end - 1)]
         else
             # The factorization may fail if the time step is too large
             # and h becomes negative.

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -581,13 +581,6 @@ function solve_system_matrix!(dv, system_matrix, rhs,
     return nothing
 end
 
-# Svärd-Kalisch equations for reflecting boundary conditions uses LU factorization
-function solve_system_matrix!(dv, system_matrix, ::SvaerdKalischEquations1D, cache)
-    (; factorization) = cache
-    lu!(factorization, system_matrix)
-    ldiv!(factorization, dv)
-end
-
 function solve_system_matrix!(dv, system_matrix, ::Union{BBMEquation1D, BBMBBMEquations1D})
     ldiv!(system_matrix, dv)
 end

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -570,7 +570,7 @@ function solve_system_matrix!(dv, system_matrix, rhs,
                                                SerreGreenNaghdiEquations1D},
                               D1, cache, ::BoundaryConditionReflecting)
     scale_by_mass_matrix!(rhs, D1)
-    solve_system_matrix!(dv, system_matrix, (@view rhs[2:(end - 1)]), equations, D1, cache)
+    solve_system_matrix!(dv, system_matrix, (@view rhs[(begin + 1):(end - 1)]), equations, D1, cache)
 end
 
 function solve_system_matrix!(dv, system_matrix, rhs,

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -581,6 +581,13 @@ function solve_system_matrix!(dv, system_matrix, rhs,
     return nothing
 end
 
+# Svärd-Kalisch equations for reflecting boundary conditions uses LU factorization
+function solve_system_matrix_lu!(dv, system_matrix_lu, ::SvaerdKalischEquations1D, cache)
+    (; factorization_lu) = cache
+    lu!(factorization_lu, system_matrix_lu)
+    ldiv!(factorization_lu, dv)
+end
+
 function solve_system_matrix!(dv, system_matrix, ::Union{BBMEquation1D, BBMBBMEquations1D})
     ldiv!(system_matrix, dv)
 end

--- a/src/equations/equations.jl
+++ b/src/equations/equations.jl
@@ -560,6 +560,22 @@ include("hyperbolic_serre_green_naghdi_1d.jl")
 function solve_system_matrix!(dv, system_matrix, rhs,
                               ::Union{SvaerdKalischEquations1D,
                                       SerreGreenNaghdiEquations1D},
+                              D1, cache, ::BoundaryConditionPeriodic)
+    scale_by_mass_matrix!(rhs, D1)
+    solve_system_matrix!(dv, system_matrix, rhs, equations, D1, cache)
+end
+
+function solve_system_matrix!(dv, system_matrix, rhs,
+                              ::Union{SvaerdKalischEquations1D,
+                                      SerreGreenNaghdiEquations1D},
+                              D1, cache, ::BoundaryConditionReflecting)
+    scale_by_mass_matrix!(rhs, D1)
+    solve_system_matrix!(dv, system_matrix, (@view rhs[2:(end - 1)]), equations, D1, cache)
+end
+
+function solve_system_matrix!(dv, system_matrix, rhs,
+                              ::Union{SvaerdKalischEquations1D,
+                                      SerreGreenNaghdiEquations1D},
                               D1, cache)
     if issparse(system_matrix)
         (; factorization) = cache

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -485,7 +485,7 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache, ::BathymetryFlat
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
-        scale_by_mass_matrix!(tmp1, D1)
+        scale_by_mass_matrix!(tmp, D1)
         solve_system_matrix!(dv, system_matrix, tmp,
                              equations, D1, cache)
     end
@@ -591,7 +591,7 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache,
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
-        scale_by_mass_matrix!(tmp1, D1)
+        scale_by_mass_matrix!(tmp, D1)
         solve_system_matrix!(dv, system_matrix, tmp,
                              equations, D1, cache)
     end
@@ -705,7 +705,7 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache,
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
-        scale_by_mass_matrix!(tmp1, D1)
+        scale_by_mass_matrix!(tmp, D1)
         solve_system_matrix!(dv, system_matrix, tmp,
                              equations, D1, cache)
     end

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -399,6 +399,7 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache, ::BathymetryFla
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
+        scale_by_mass_matrix!(tmp, D1)
         solve_system_matrix!(dv, system_matrix, tmp,
                              equations, D1, cache)
     end
@@ -484,6 +485,7 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache, ::BathymetryFlat
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
+        scale_by_mass_matrix!(tmp1, D1)
         solve_system_matrix!(dv, system_matrix, tmp,
                              equations, D1, cache)
     end
@@ -589,6 +591,7 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache,
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
+        scale_by_mass_matrix!(tmp1, D1)
         solve_system_matrix!(dv, system_matrix, tmp,
                              equations, D1, cache)
     end
@@ -702,6 +705,7 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache,
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
+        scale_by_mass_matrix!(tmp1, D1)
         solve_system_matrix!(dv, system_matrix, tmp,
                              equations, D1, cache)
     end

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -318,9 +318,11 @@ function rhs!(dq, q, t, mesh,
               source_terms::Nothing,
               solver, cache)
     if cache.D1 isa PeriodicUpwindOperators
-        rhs_sgn_upwind!(dq, q, equations, source_terms, cache, equations.bathymetry_type, boundary_conditions)
+        rhs_sgn_upwind!(dq, q, equations, source_terms, cache, equations.bathymetry_type,
+                        boundary_conditions)
     else
-        rhs_sgn_central!(dq, q, equations, source_terms, cache, equations.bathymetry_type, boundary_conditions)
+        rhs_sgn_central!(dq, q, equations, source_terms, cache, equations.bathymetry_type,
+                         boundary_conditions)
     end
 
     return nothing

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -314,19 +314,20 @@ end
 function rhs!(dq, q, t, mesh,
               equations::SerreGreenNaghdiEquations1D,
               initial_condition,
-              ::BoundaryConditionPeriodic,
+              boundary_conditions::BoundaryConditionPeriodic,
               source_terms::Nothing,
               solver, cache)
     if cache.D1 isa PeriodicUpwindOperators
-        rhs_sgn_upwind!(dq, q, equations, source_terms, cache, equations.bathymetry_type)
+        rhs_sgn_upwind!(dq, q, equations, source_terms, cache, equations.bathymetry_type, boundary_conditions)
     else
-        rhs_sgn_central!(dq, q, equations, source_terms, cache, equations.bathymetry_type)
+        rhs_sgn_central!(dq, q, equations, source_terms, cache, equations.bathymetry_type, boundary_conditions)
     end
 
     return nothing
 end
 
-function rhs_sgn_central!(dq, q, equations, source_terms, cache, ::BathymetryFlat)
+function rhs_sgn_central!(dq, q, equations, source_terms, cache, ::BathymetryFlat,
+                          boundary_conditions::BoundaryConditionPeriodic)
     # Unpack physical parameters and SBP operator `D1` as well as the
     # SBP operator in sparse matrix form `D1mat`
     g = gravity_constant(equations)
@@ -406,7 +407,8 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache, ::BathymetryFla
     return nothing
 end
 
-function rhs_sgn_upwind!(dq, q, equations, source_terms, cache, ::BathymetryFlat)
+function rhs_sgn_upwind!(dq, q, equations, source_terms, cache, ::BathymetryFlat,
+                         boundary_conditions::BoundaryConditionPeriodic)
     # Unpack physical parameters and SBP operator `D1` as well as the
     # SBP upwind operator in sparse matrix form `D1mat_minus`
     g = gravity_constant(equations)
@@ -492,7 +494,8 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache, ::BathymetryFlat
 end
 
 function rhs_sgn_central!(dq, q, equations, source_terms, cache,
-                          ::Union{BathymetryMildSlope, BathymetryVariable})
+                          ::Union{BathymetryMildSlope, BathymetryVariable},
+                          boundary_conditions::BoundaryConditionPeriodic)
     # Unpack physical parameters and SBP operator `D1` as well as the
     # SBP operator in sparse matrix form `D1mat`
     g = gravity_constant(equations)
@@ -597,7 +600,8 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache,
 end
 
 function rhs_sgn_upwind!(dq, q, equations, source_terms, cache,
-                         ::Union{BathymetryMildSlope, BathymetryVariable})
+                         ::Union{BathymetryMildSlope, BathymetryVariable},
+                         boundary_conditions::BoundaryConditionPeriodic)
     # Unpack physical parameters and SBP operator `D1` as well as the
     # SBP operator in sparse matrix form `D1mat`
     g = gravity_constant(equations)

--- a/src/equations/serre_green_naghdi_1d.jl
+++ b/src/equations/serre_green_naghdi_1d.jl
@@ -399,9 +399,8 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache, ::BathymetryFla
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
-        scale_by_mass_matrix!(tmp, D1)
-        solve_system_matrix!(dv, system_matrix, tmp,
-                             equations, D1, cache)
+        solve_system_matrix!(dv, system_matrix,
+                             tmp, equations, D1, cache, boundary_conditions)
     end
 
     return nothing
@@ -485,9 +484,8 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache, ::BathymetryFlat
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
-        scale_by_mass_matrix!(tmp, D1)
-        solve_system_matrix!(dv, system_matrix, tmp,
-                             equations, D1, cache)
+        solve_system_matrix!(dv, system_matrix,
+                             tmp, equations, D1, cache, boundary_conditions)
     end
 
     return nothing
@@ -591,9 +589,8 @@ function rhs_sgn_central!(dq, q, equations, source_terms, cache,
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
-        scale_by_mass_matrix!(tmp, D1)
-        solve_system_matrix!(dv, system_matrix, tmp,
-                             equations, D1, cache)
+        solve_system_matrix!(dv, system_matrix,
+                             tmp, equations, D1, cache, boundary_conditions)
     end
 
     return nothing
@@ -705,9 +702,8 @@ function rhs_sgn_upwind!(dq, q, equations, source_terms, cache,
     end
 
     @trixi_timeit timer() "solving elliptic system" begin
-        scale_by_mass_matrix!(tmp, D1)
-        solve_system_matrix!(dv, system_matrix, tmp,
-                             equations, D1, cache)
+        solve_system_matrix!(dv, system_matrix,
+                             tmp, equations, D1, cache, boundary_conditions)
     end
 
     return nothing

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -502,7 +502,7 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
     @trixi_timeit timer() "solving elliptic system" begin
         tmp1 .= dv
         solve_system_matrix!((@view dv[2:(end - 1)]), system_matrix,
-                             (@view tmp1[2:(end - 1)]), equations, D1,
+                             tmp1, equations, D1,
                              cache)
         dv[1] = dv[end] = zero(eltype(dv))
     end

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -487,7 +487,8 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
     end
     @trixi_timeit timer() "solving elliptic system" begin
         tmp1 .= dv
-        solve_system_matrix!((@view dv[2:(end - 1)]), system_matrix, (@view tmp1[2:(end - 1)]), equations, D1,
+        solve_system_matrix!((@view dv[2:(end - 1)]), system_matrix,
+                             (@view tmp1[2:(end - 1)]), equations, D1,
                              cache)
         dv[1] = dv[end] = zero(eltype(dv))
     end

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -288,7 +288,7 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
                       solver, initial_condition,
                       ::BoundaryConditionReflecting,
                       RealT, uEltype)
-    if !iszero(equations.alpha) || !iszero(equations.gamma,)
+    if !iszero(equations.alpha) || !iszero(equations.gamma)
         throw(ArgumentError("Reflecting boundary conditions for Svärd-Kalisch equations only implemented for alpha = gamma = 0"))
     end
     D1 = solver.D1

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -223,13 +223,6 @@ function assemble_system_matrix!(cache, h,
     return Symmetric(Diagonal((@view M_h[2:(end - 1)])) + minus_MD1betaD1)
 end
 
-function assemble_system_matrix_lu!(cache, h,
-                                    ::SvaerdKalischEquations1D,
-                                    ::BoundaryConditionReflecting)
-    (; D1betaD1d) = cache
-    return Diagonal((@view h[2:(end - 1)])) - D1betaD1d
-end
-
 function create_cache(mesh, equations::SvaerdKalischEquations1D,
                       solver, initial_condition,
                       boundary_conditions::BoundaryConditionPeriodic,
@@ -333,14 +326,9 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
        D1 isa UniformCoupledOperator
         D1_central = D1
         D1mat = sparse(D1_central)
-        D1betaD1d = sparse(D1mat * Diagonal(beta_hat) * D1mat * Pd)[2:(end - 1), :]
         minus_MD1betaD1 = sparse(D1mat' * Diagonal(M_beta) * D1mat * Pd)[2:(end - 1), :]
         system_matrix = let cache = (; D1, M_h, minus_MD1betaD1)
             assemble_system_matrix!(cache, h, equations, boundary_conditions)
-        end
-        system_matrix_lu = let cache = (; D1betaD1d)
-            assemble_system_matrix_lu!(cache, h,
-                                       equations, boundary_conditions)
         end
     elseif D1 isa UpwindOperators
         D1_central = D1.central
@@ -354,9 +342,7 @@ function create_cache(mesh, equations::SvaerdKalischEquations1D,
         throw(ArgumentError("unknown type of first-derivative operator: $(typeof(D1))"))
     end
     factorization = cholesky(system_matrix)
-    factorization_lu = lu(system_matrix_lu)
-    cache = (; factorization, factorization_lu, minus_MD1betaD1, D1betaD1d, D, h, hv, b,
-             eta_x, v_x,
+    cache = (; factorization, minus_MD1betaD1, D, h, hv, b, eta_x, v_x,
              h_v_x, hv2_x, beta_hat, D1_central, D1, M_h)
     return cache
 end
@@ -504,50 +490,6 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
         solve_system_matrix!((@view dv[2:(end - 1)]), system_matrix,
                              tmp1, equations, D1,
                              cache)
-        dv[1] = dv[end] = zero(eltype(dv))
-    end
-
-    return nothing
-end
-
-function rhs_lu!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
-                 initial_condition, boundary_conditions::BoundaryConditionReflecting,
-                 source_terms, solver, cache)
-    # When constructing the `cache`, we assert that alpha and gamma are zero.
-    # We use this explicitly in the code below.
-    (; D, h, hv, b, eta_x, v_x, h_v_x, hv2_x, tmp1, D1_central, D1) = cache
-
-    g = gravity_constant(equations)
-    eta, v = q.x
-    deta, dv, dD = dq.x
-    fill!(dD, zero(eltype(dD)))
-
-    @trixi_timeit timer() "deta hyperbolic" begin
-        @.. b = equations.eta0 - D
-        @.. h = eta - b
-        @.. hv = h * v
-
-        mul!(deta, D1_central, -hv)
-    end
-
-    # split form
-    @trixi_timeit timer() "dv hyperbolic" begin
-        mul!(eta_x, D1_central, eta)
-        mul!(v_x, D1_central, v)
-        mul!(h_v_x, D1_central, hv)
-        @.. tmp1 = hv * v
-        mul!(hv2_x, D1_central, tmp1)
-        @.. dv = -(0.5 * (hv2_x + hv * v_x - v * h_v_x) +
-                   g * h * eta_x)
-    end
-
-    @trixi_timeit timer() "source terms" calc_sources!(dq, q, t, source_terms, equations,
-                                                       solver)
-    @trixi_timeit timer() "assemble system matrix" begin
-        system_matrix_lu = assemble_system_matrix_lu!(cache, h, equations, boundary_conditions)
-    end
-    @trixi_timeit timer() "solving elliptic system" begin
-        solve_system_matrix_lu!((@view dv[2:(end - 1)]), system_matrix_lu, equations, cache)
         dv[1] = dv[end] = zero(eltype(dv))
     end
 

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -442,9 +442,8 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
     end
     @trixi_timeit timer() "solving elliptic system" begin
         tmp1 .= dv
-        scale_by_mass_matrix!(tmp1, D1)
-        solve_system_matrix!(dv, system_matrix, tmp1,
-                             equations, D1, cache)
+        solve_system_matrix!(dv, system_matrix,
+                             tmp1, equations, D1, cache, boundary_conditions)
     end
 
     return nothing
@@ -488,10 +487,8 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
     end
     @trixi_timeit timer() "solving elliptic system" begin
         tmp1 .= dv
-        scale_by_mass_matrix!(tmp1, D1)
         solve_system_matrix!((@view dv[2:(end - 1)]), system_matrix,
-                             (@view tmp1[2:(end - 1)]), equations, D1,
-                             cache)
+                             tmp1, equations, D1, cache, boundary_conditions)
         dv[1] = dv[end] = zero(eltype(dv))
     end
 

--- a/src/equations/svaerd_kalisch_1d.jl
+++ b/src/equations/svaerd_kalisch_1d.jl
@@ -442,6 +442,7 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
     end
     @trixi_timeit timer() "solving elliptic system" begin
         tmp1 .= dv
+        scale_by_mass_matrix!(tmp1, D1)
         solve_system_matrix!(dv, system_matrix, tmp1,
                              equations, D1, cache)
     end
@@ -487,8 +488,9 @@ function rhs!(dq, q, t, mesh, equations::SvaerdKalischEquations1D,
     end
     @trixi_timeit timer() "solving elliptic system" begin
         tmp1 .= dv
+        scale_by_mass_matrix!(tmp1, D1)
         solve_system_matrix!((@view dv[2:(end - 1)]), system_matrix,
-                             tmp1, equations, D1,
+                             (@view tmp1[2:(end - 1)]), equations, D1,
                              cache)
         dv[1] = dv[end] = zero(eltype(dv))
     end

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -17,6 +17,38 @@ end
     @test_allocations(semi, sol, allocs=90_000)
 end
 
+@testitem "svaerd_kalisch_1d_basic_reflecting" setup=[Setup, SvaerdKalischEquations1D, AdditionalImports] begin
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
+                        tspan=(0.0, 1.0),
+                        l2=[4.067039325687744e-5 6.705583873243185e-8 0.0],
+                        linf=[0.00028373482419530305 1.4602668701318988e-7 0.0],
+                        cons_error=[1.0484869654379814e-9 0.5469460930247622 0.0],
+                        change_waterheight=1.0484869654379814e-9,
+                        change_velocity=0.5469460930247622,
+                        change_entropy=14.059432069002527)
+
+    @test_allocations(semi, sol, allocs=650_000)
+
+    # # test upwind operators
+    # D1 = upwind_operators(Mattsson2017; derivative_order = 1,
+    #                       accuracy_order = accuracy_order, xmin = mesh.xmin,
+    #                       xmax = mesh.xmax,
+    #                       N = mesh.N)
+    # D2 = sparse(D1.plus) * sparse(D1.minus)
+    # solver = Solver(D1, D2)
+    # @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
+    #                     tspan=(0.0, 1.0),
+    #                     solver=solver,
+    #                     l2=[0.002345799818043513 3.254313503127441e-8 0.0],
+    #                     linf=[0.05625950533062252 6.815531732318192e-7 0.0],
+    #                     cons_error=[1.6607871307809518e-9 0.5469460993745239 0.0],
+    #                     change_waterheight=-1.6607871307809518e-9,
+    #                     change_velocity=0.5469460993745239,
+    #                     change_entropy=132.10938489083918)
+
+    # @test_allocations(semi, sol, allocs=2_000)
+end
+
 @testitem "svaerd_kalisch_1d_dingemans" setup=[
     Setup,
     SvaerdKalischEquations1D,

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -28,7 +28,8 @@ end
                         linf=[9.787584609100008e-5 1.4602668577112787e-7 0.0],
                         cons_error=[1.0484865187415942e-9 0.5469460930247753 0.0],
                         change_waterheight=1.0484865187415942e-9,
-                        change_entropy_modified=459.9037236233692)
+                        change_entropy_modified=459.9037236233692,
+                        atol=1e-11) # to make CI pass
 
     @test_allocations(semi, sol, allocs=650_000)
 
@@ -45,7 +46,8 @@ end
                         linf=[3.135229084794133e-5 8.797788287467911e-8 0.0],
                         cons_error=[1.700425282207037e-9 0.5469460935004404 0.0],
                         change_waterheight=-1.700425282207037e-9,
-                        change_entropy_modified=459.9037221442477)
+                        change_entropy_modified=459.9037221442477,
+                        atol=1e-11) # to make CI pass
 
     @test_allocations(semi, sol, allocs=650_000)
 end

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -24,11 +24,11 @@ end
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
                         tspan=(0.0, 1.0),
-                        l2=[5.402315467757905e-6 6.705583190754449e-8 0.0],
-                        linf=[9.787584609100008e-5 1.4602668577112787e-7 0.0],
-                        cons_error=[1.0484865187415942e-9 0.5469460930247753 0.0],
-                        change_waterheight=1.0484865187415942e-9,
-                        change_entropy_modified=459.9037236233692,
+                        l2=[5.402315494643131e-6 6.70558305594986e-8 0.0],
+                        linf=[9.787585531206844e-5 1.460266869784954e-7 0.0],
+                        cons_error=[1.0484871583691058e-9 0.5469460930247998 0.0],
+                        change_waterheight=1.0484871583691058e-9,
+                        change_entropy_modified=459.90372362340514,
                         atol=1e-11) # to make CI pass
 
     @test_allocations(semi, sol, allocs=650_000)
@@ -42,11 +42,11 @@ end
     @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
                         tspan=(0.0, 1.0),
                         solver=solver,
-                        l2=[5.862278093002509e-6 4.111933117101271e-9 0.0],
-                        linf=[3.135229084794133e-5 8.797788287467911e-8 0.0],
-                        cons_error=[1.700425282207037e-9 0.5469460935004404 0.0],
-                        change_waterheight=-1.700425282207037e-9,
-                        change_entropy_modified=459.9037221442477,
+                        l2=[5.862278175937948e-6 4.11195454078554e-9 0.0],
+                        linf=[3.135228725170691e-5 8.797787950237668e-8 0.0],
+                        cons_error=[1.700425028441774e-9 0.5469460935005555 0.0],
+                        change_waterheight=-1.700425028441774e-9,
+                        change_entropy_modified=459.9037221442321,
                         atol=1e-11) # to make CI pass
 
     @test_allocations(semi, sol, allocs=650_000)

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -17,7 +17,11 @@ end
     @test_allocations(semi, sol, allocs=90_000)
 end
 
-@testitem "svaerd_kalisch_1d_basic_reflecting" setup=[Setup, SvaerdKalischEquations1D, AdditionalImports] begin
+@testitem "svaerd_kalisch_1d_basic_reflecting" setup=[
+    Setup,
+    SvaerdKalischEquations1D,
+    AdditionalImports
+] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
                         tspan=(0.0, 1.0),
                         l2=[4.067039325687744e-5 6.705583873243185e-8 0.0],

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -28,7 +28,8 @@ end
                         linf=[9.787585531206844e-5 1.460266869784954e-7 0.0],
                         cons_error=[1.0484871583691058e-9 0.5469460930247998 0.0],
                         change_waterheight=1.0484871583691058e-9,
-                        change_entropy_modified=459.90372362340514)
+                        change_entropy_modified=459.90372362340514,
+                        atol=1e-11) # to make CI pass
 
     @test_allocations(semi, sol, allocs=650_000)
 
@@ -45,7 +46,8 @@ end
                         linf=[3.135228725170691e-5 8.797787950237668e-8 0.0],
                         cons_error=[1.700425028441774e-9 0.5469460935005555 0.0],
                         change_waterheight=-1.700425028441774e-9,
-                        change_entropy_modified=459.9037221442321)
+                        change_entropy_modified=459.9037221442321,
+                        atol=1e-10) # to make CI pass
 
     @test_allocations(semi, sol, allocs=650_000)
 end

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -24,11 +24,11 @@ end
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
                         tspan=(0.0, 1.0),
-                        l2=[4.067039325687744e-5 6.705583873243185e-8 0.0],
-                        linf=[0.00028373482419530305 1.4602668701318988e-7 0.0],
-                        cons_error=[1.0484869654379814e-9 0.5469460930247622 0.0],
-                        change_waterheight=1.0484869654379814e-9,
-                        change_entropy_modified=459.90372362418947)
+                        l2=[5.402315467757905e-6 6.705583190754449e-8 0.0],
+                        linf=[9.787584609100008e-5 1.4602668577112787e-7 0.0],
+                        cons_error=[1.0484865187415942e-9 0.5469460930247753 0.0],
+                        change_waterheight=1.0484865187415942e-9,
+                        change_entropy_modified=459.9037236233692)
 
     @test_allocations(semi, sol, allocs=650_000)
 
@@ -41,11 +41,11 @@ end
     @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
                         tspan=(0.0, 1.0),
                         solver=solver,
-                        l2=[5.1845375611538653e-5 4.111955051600758e-9 0.0],
-                        linf=[0.0003710888676375923 8.797788351305735e-8 0.0],
-                        cons_error=[1.7004244096716813e-9 0.5469460935005923 0.0],
-                        change_waterheight=-1.7004244096716813e-9,
-                        change_entropy_modified=459.9037221456176)
+                        l2=[5.862278093002509e-6 4.111933117101271e-9 0.0],
+                        linf=[3.135229084794133e-5 8.797788287467911e-8 0.0],
+                        cons_error=[1.700425282207037e-9 0.5469460935004404 0.0],
+                        change_waterheight=-1.700425282207037e-9,
+                        change_entropy_modified=459.9037221442477)
 
     @test_allocations(semi, sol, allocs=650_000)
 end

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -28,29 +28,26 @@ end
                         linf=[0.00028373482419530305 1.4602668701318988e-7 0.0],
                         cons_error=[1.0484869654379814e-9 0.5469460930247622 0.0],
                         change_waterheight=1.0484869654379814e-9,
-                        change_velocity=0.5469460930247622,
-                        change_entropy=14.059432069002527)
+                        change_entropy_modified=459.90372362418947)
 
     @test_allocations(semi, sol, allocs=650_000)
 
-    # # test upwind operators
-    # D1 = upwind_operators(Mattsson2017; derivative_order = 1,
-    #                       accuracy_order = accuracy_order, xmin = mesh.xmin,
-    #                       xmax = mesh.xmax,
-    #                       N = mesh.N)
-    # D2 = sparse(D1.plus) * sparse(D1.minus)
-    # solver = Solver(D1, D2)
-    # @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
-    #                     tspan=(0.0, 1.0),
-    #                     solver=solver,
-    #                     l2=[0.002345799818043513 3.254313503127441e-8 0.0],
-    #                     linf=[0.05625950533062252 6.815531732318192e-7 0.0],
-    #                     cons_error=[1.6607871307809518e-9 0.5469460993745239 0.0],
-    #                     change_waterheight=-1.6607871307809518e-9,
-    #                     change_velocity=0.5469460993745239,
-    #                     change_entropy=132.10938489083918)
+    # test upwind operators
+    D1 = upwind_operators(Mattsson2017; derivative_order = 1,
+                          accuracy_order = accuracy_order, xmin = mesh.xmin,
+                          xmax = mesh.xmax,
+                          N = mesh.N)
+    solver = Solver(D1, nothing)
+    @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
+                        tspan=(0.0, 1.0),
+                        solver=solver,
+                        l2=[5.1845375611538653e-5 4.111955051600758e-9 0.0],
+                        linf=[0.0003710888676375923 8.797788351305735e-8 0.0],
+                        cons_error=[1.7004244096716813e-9 0.5469460935005923 0.0],
+                        change_waterheight=-1.7004244096716813e-9,
+                        change_entropy_modified=459.9037221456176)
 
-    # @test_allocations(semi, sol, allocs=2_000)
+    @test_allocations(semi, sol, allocs=650_000)
 end
 
 @testitem "svaerd_kalisch_1d_dingemans" setup=[

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -24,6 +24,8 @@ end
 ] begin
     @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
                         tspan=(0.0, 1.0),
+                        abstol=1e-12,
+                        reltol=1e-12, # this example is relatively unstable with higher tolerances
                         l2=[5.402315494643131e-6 6.70558305594986e-8 0.0],
                         linf=[9.787585531206844e-5 1.460266869784954e-7 0.0],
                         cons_error=[1.0484871583691058e-9 0.5469460930247998 0.0],
@@ -42,6 +44,8 @@ end
     @test_trixi_include(joinpath(EXAMPLES_DIR, "svaerd_kalisch_1d_basic_reflecting.jl"),
                         tspan=(0.0, 1.0),
                         solver=solver,
+                        abstol=1e-12,
+                        reltol=1e-12, # this example is relatively unstable with higher tolerances
                         l2=[5.862278175937948e-6 4.11195454078554e-9 0.0],
                         linf=[3.135228725170691e-5 8.797787950237668e-8 0.0],
                         cons_error=[1.700425028441774e-9 0.5469460935005555 0.0],

--- a/test/test_svaerd_kalisch_1d.jl
+++ b/test/test_svaerd_kalisch_1d.jl
@@ -28,8 +28,7 @@ end
                         linf=[9.787585531206844e-5 1.460266869784954e-7 0.0],
                         cons_error=[1.0484871583691058e-9 0.5469460930247998 0.0],
                         change_waterheight=1.0484871583691058e-9,
-                        change_entropy_modified=459.90372362340514,
-                        atol=1e-11) # to make CI pass
+                        change_entropy_modified=459.90372362340514)
 
     @test_allocations(semi, sol, allocs=650_000)
 
@@ -46,8 +45,7 @@ end
                         linf=[3.135228725170691e-5 8.797787950237668e-8 0.0],
                         cons_error=[1.700425028441774e-9 0.5469460935005555 0.0],
                         change_waterheight=-1.700425028441774e-9,
-                        change_entropy_modified=459.9037221442321,
-                        atol=1e-11) # to make CI pass
+                        change_entropy_modified=459.9037221442321)
 
     @test_allocations(semi, sol, allocs=650_000)
 end

--- a/test/test_unit.jl
+++ b/test/test_unit.jl
@@ -250,6 +250,15 @@ end
         U_modified_total = @inferred DispersiveShallowWater.integrate(U_modified, semi)
         @test isapprox(U_modified_total, e_modified_total)
     end
+
+    @testset "reflecting boundary conditions" begin
+        initial_condition = initial_condition_manufactured_reflecting
+        boundary_conditions = boundary_condition_reflecting
+        mesh = Mesh1D(-1.0, 1.0, 10)
+        solver = Solver(mesh, 4)
+        @test_throws ArgumentError Semidiscretization(mesh, equations, initial_condition,
+                                                      solver; boundary_conditions)
+    end
 end
 
 @testitem "SerreGreenNaghdiEquations1D" setup=[Setup] begin


### PR DESCRIPTION
In the case of $\alpha = \gamma = 0$ reflecting boundary conditions for the Svärd-Kalisch equations satisfy an entropy condition. This PR adds this possibility.

I used an LU factorization instead of a Cholesky decomposition for the system matrix for now because it was a bit simpler to implement and I was not 100% sure if the Dirichlet operator matrix $(\eta + D) - P_DD_1\hat{\beta}D_1$ is always guaranteed to be SPD (or rather the `[2:(end - 1), (2:end - 1)]` block of it). I would need to check that.

Regarding the treatment of the boundary conditions: We apply a Dirichlet operator in the equation for the velocity and explicitly set the boundary conditions `v_1 = v_N = 0` enforcing the boundary condition strongly. As I understand, for the mass equation no special treatment  of the boundary condition is necessary as we don't have any elliptic operator and a SAT term would simply be zero as the flux vanishes on the boundary (because the velocity vanishes on the boundary). Correct me if I'm wrong, @ranocha.

Convergence study looks a bit odd sometimes (e.g., convergence in $v$ for p = 6), but seems mostly ok:
<details>
<summary>p = 2</summary>

```julia
julia> convergence_test("examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl", 4, N = 16, accuracy_order = 2);
[...]
####################################################################################################
l2
η                        v                        D                        
N    error     EOC       N    error     EOC       N    error     EOC       
16   3.82e-01  -         16   2.20e-02  -         16   0.00e+00  -         
32   1.27e-01  1.59      32   4.82e-03  2.19      32   0.00e+00  NaN       
64   4.44e-02  1.52      64   1.15e-03  2.07      64   0.00e+00  NaN       
128  1.58e-02  1.48      128  2.82e-04  2.03      128  0.00e+00  NaN       

mean           1.53      mean           2.10      mean           NaN       
----------------------------------------------------------------------------------------------------
linf
η                        v                        D                        
N    error     EOC       N    error     EOC       N    error     EOC       
16   1.77e+00  -         16   4.06e-02  -         16   0.00e+00  -         
32   8.73e-01  1.02      32   9.30e-03  2.13      32   0.00e+00  NaN       
64   4.33e-01  1.01      64   2.24e-03  2.05      64   0.00e+00  NaN       
128  2.15e-01  1.01      128  5.50e-04  2.03      128  0.00e+00  NaN       

mean           1.01      mean           2.07      mean           NaN       
----------------------------------------------------------------------------------------------------
```

</details>

<details>
<summary>p = 4</summary>

```julia
julia> convergence_test("examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl", 4, N = 16, accuracy_order = 4);
[...]
####################################################################################################
l2
η                        v                        D                        
N    error     EOC       N    error     EOC       N    error     EOC       
16   1.62e-01  -         16   2.73e-03  -         16   0.00e+00  -         
32   1.62e-02  3.32      32   2.20e-04  3.64      32   0.00e+00  NaN       
64   1.74e-03  3.21      64   3.04e-05  2.85      64   0.00e+00  NaN       
128  2.21e-04  2.98      128  4.11e-06  2.89      128  0.00e+00  NaN       

mean           3.17      mean           3.12      mean           NaN       
----------------------------------------------------------------------------------------------------
linf
η                        v                        D                        
N    error     EOC       N    error     EOC       N    error     EOC       
16   5.99e-01  -         16   5.12e-03  -         16   0.00e+00  -         
32   5.68e-02  3.40      32   5.87e-04  3.12      32   0.00e+00  NaN       
64   6.22e-03  3.19      64   7.38e-05  2.99      64   0.00e+00  NaN       
128  1.55e-03  2.00      128  9.30e-06  2.99      128  0.00e+00  NaN       

mean           2.87      mean           3.03      mean           NaN       
----------------------------------------------------------------------------------------------------
```

</details>

<details>
<summary>p = 6</summary>

```julia
julia> convergence_test("examples/svaerd_kalisch_1d/svaerd_kalisch_1d_basic_reflecting.jl", 4, N = 16, accuracy_order = 6);
####################################################################################################
l2
η                        v                        D                        
N    error     EOC       N    error     EOC       N    error     EOC       
16   7.65e-01  -         16   1.55e-02  -         16   0.00e+00  -         
32   6.70e-02  3.51      32   4.49e-05  8.43      32   0.00e+00  NaN       
64   3.97e-03  4.08      64   2.28e-05  0.98      64   0.00e+00  NaN       
128  3.06e-04  3.70      128  1.52e-06  3.91      128  0.00e+00  NaN       

mean           3.76      mean           4.44      mean           NaN       
----------------------------------------------------------------------------------------------------
linf
η                        v                        D                        
N    error     EOC       N    error     EOC       N    error     EOC       
16   2.63e+00  -         16   4.05e-02  -         16   0.00e+00  -         
32   3.68e-01  2.84      32   1.30e-04  8.28      32   0.00e+00  NaN       
64   2.72e-02  3.76      64   4.13e-05  1.65      64   0.00e+00  NaN       
128  2.37e-03  3.52      128  2.43e-06  4.09      128  0.00e+00  NaN       

mean           3.37      mean           4.68      mean           NaN       
----------------------------------------------------------------------------------------------------
```

</details>

TODO:
- [x] Upwind operators